### PR TITLE
[perf]: backport changes from thunder perf hackathon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -189,6 +189,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3057,8 @@ version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -4063,6 +4071,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "667f4fec20f29dfc6bc7357c582d91796c169ad7e2fce709468aefeb2c099870"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "libredox"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4323,6 +4341,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1ee66a4b64c74f4ef288bcbb9192ad9c3feaad75193129ac8509af543894fd8"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -6861,6 +6888,7 @@ dependencies = [
 name = "thunder_orchard"
 version = "0.12.6"
 dependencies = [
+ "ahash",
  "anyhow",
  "async-lock",
  "bincode",
@@ -6877,6 +6905,7 @@ dependencies = [
  "futures",
  "governor",
  "halo2_proofs",
+ "hashbrown 0.15.2",
  "hashlink 0.10.0",
  "heed",
  "hex 0.4.3",
@@ -6901,6 +6930,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "shardtree",
+ "smallvec",
  "sneed",
  "strum 0.26.3",
  "thiserror 2.0.12",
@@ -6933,6 +6963,7 @@ dependencies = [
  "human-size",
  "include_path",
  "jsonrpsee",
+ "mimalloc",
  "parking_lot",
  "poll-promise",
  "rustreexo",
@@ -6968,6 +6999,7 @@ dependencies = [
  "clap",
  "http 1.3.1",
  "jsonrpsee",
+ "mimalloc",
  "serde_json",
  "thunder_orchard",
  "thunder_orchard_app_rpc_api",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -19,6 +19,7 @@ http = { workspace = true }
 human-size = "0.4.3"
 include_path = "0.1.1"
 jsonrpsee = { workspace = true, features = ["server"] }
+mimalloc = { version = "0.1.48", features = ["v3"] }
 parking_lot = { workspace = true }
 poll-promise = { version = "0.3.0", features = ["tokio"] }
 rustreexo = { workspace = true }

--- a/app/app.rs
+++ b/app/app.rs
@@ -25,6 +25,7 @@ use tonic_health::{
 
 use crate::cli::Config;
 
+#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, thiserror::Error, transitive::Transitive)]
 #[transitive(
     from(thunder_orchard::archive::Error, node::Error),

--- a/app/main.rs
+++ b/app/main.rs
@@ -1,7 +1,7 @@
-use std::path::Path;
-
 use clap::Parser as _;
+use std::{env, path::Path};
 
+use mimalloc::MiMalloc;
 use tokio::{signal::ctrl_c, sync::oneshot};
 use tracing_subscriber::{
     Layer, filter as tracing_filter, fmt::format, layer::SubscriberExt,
@@ -16,6 +16,26 @@ mod util;
 
 use line_buffer::{LineBuffer, LineBufferWriter};
 use util::saturating_pred_level;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+pub fn configure_mimalloc() {
+    // This code is safe because it only sets environment variables
+    unsafe {
+        env::set_var("MIMALLOC_ABANDONED_PAGE_LIMIT", "4");
+        env::set_var("MIMALLOC_ABANDONED_PAGE_RESET", "1");
+        env::set_var("MIMALLOC_ARENA_LIMIT", "4");
+        env::set_var("MIMALLOC_USE_NUMA_NODES", "all");
+        env::set_var("MIMALLOC_EAGER_COMMIT", "1");
+        env::set_var("MIMALLOC_EAGER_REGION_COMMIT", "1");
+        env::set_var("MIMALLOC_SEGMENT_CACHE", "32"); // Increase from default 4. Costs RAM
+        env::set_var("MIMALLOC_LARGE_OS_PAGES", "1"); // Use large OS pages - something to play around with tbh
+        env::set_var("MIMALLOC_RESERVE_HUGE_OS_PAGES", "4"); // Reserve 4x2MB = 8MB huge pages
+        env::set_var("MIMALLOC_PAGE_RESET", "0"); // Don't zero pages on free
+        env::set_var("MIMALLOC_SEGMENT_RESET", "0");
+    }
+}
 
 /// The empty string target `""` can be used to set a default level.
 fn targets_directive_str<'a, Targets>(targets: Targets) -> String
@@ -164,6 +184,8 @@ fn run_egui_app(
 }
 
 fn main() -> anyhow::Result<()> {
+    configure_mimalloc();
+
     let cli = cli::Cli::parse();
     let config = cli.get_config()?;
     let (line_buffer, _rolling_log_guard) = set_tracing_subscriber(

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,6 +12,7 @@ bitcoin = { workspace = true, features = ["serde"] }
 clap = { version = "4.5.4", features = ["derive"] }
 http = { workspace = true }
 jsonrpsee = { workspace = true, features = ["http-client"] }
+mimalloc = { version = "0.1.48", features = ["v3"] }
 serde_json = { workspace = true }
 thunder_orchard = { path = "../lib" }
 thunder_orchard_app_rpc_api = { path = "../rpc-api" }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -1,8 +1,29 @@
 use clap::Parser;
+use mimalloc::MiMalloc;
 use thunder_orchard_app_cli_lib::Cli;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+fn configure_mimalloc() {
+    // Same tuning as the app binary
+    unsafe {
+        std::env::set_var("MIMALLOC_ABANDONED_PAGE_LIMIT", "4");
+        std::env::set_var("MIMALLOC_ABANDONED_PAGE_RESET", "1");
+        std::env::set_var("MIMALLOC_ARENA_LIMIT", "4");
+        std::env::set_var("MIMALLOC_USE_NUMA_NODES", "all");
+        std::env::set_var("MIMALLOC_EAGER_COMMIT", "1");
+        std::env::set_var("MIMALLOC_EAGER_REGION_COMMIT", "1");
+        std::env::set_var("MIMALLOC_SEGMENT_CACHE", "32");
+        std::env::set_var("MIMALLOC_LARGE_OS_PAGES", "1");
+        std::env::set_var("MIMALLOC_RESERVE_HUGE_OS_PAGES", "4");
+        std::env::set_var("MIMALLOC_PAGE_RESET", "0");
+        std::env::set_var("MIMALLOC_SEGMENT_RESET", "0");
+    }
+}
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    configure_mimalloc();
     let cli = Cli::parse();
     let res = cli.run().await?;
     #[allow(clippy::print_stdout)]

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,13 +13,14 @@ protox = "0.7.1"
 tonic-build = "0.12.3"
 
 [dependencies]
+ahash = "0.8"
 anyhow = { workspace = true, features = ["backtrace"] }
 async-lock = "3.4.0"
 bincode = { workspace = true }
 bitcoin = { workspace = true, features = ["serde"] }
 blake3 = "1.4.1"
 borsh = { version = "1.3.1", features = ["derive"] }
-bytemuck = "1.22.0"
+bytemuck = { version = "1.22.0", features = ["extern_crate_alloc"] }
 bytes = "1.4.0"
 clap = { workspace = true, features = ["derive"], optional = true }
 ed25519-dalek = { version = "2.1.1", features = ["batch", "serde"] }
@@ -27,11 +28,13 @@ fallible-iterator = { workspace = true }
 fatality = "0.1.1"
 futures = "0.3.30"
 halo2_proofs = { version = "0.3.0", default-features = false }
+hashbrown = "0.15"
 hashlink = { version = "0.10.0", features = ["serde_impl"] }
 heed = "0.21.0"
 hex = { version = "0.4.3", features = ["serde"] }
 incrementalmerkletree = "0.8.2"
 jsonrpsee = { workspace = true }
+smallvec = { version = "1.13.2", features = ["write"] }
 nonempty = { version = "0.11.0", features = ["serialize"] }
 orchard = "0.11.0"
 parking_lot = { workspace = true, features = ["arc_lock"]}

--- a/lib/mempool.rs
+++ b/lib/mempool.rs
@@ -11,6 +11,7 @@ use crate::types::{
     VERSION, Version, orchard::Nullifier,
 };
 
+#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Transitive)]
 #[transitive(
     from(db::error::Delete, db::Error),

--- a/lib/net/error.rs
+++ b/lib/net/error.rs
@@ -12,6 +12,7 @@ use crate::net::PeerConnectionError;
 pub struct AlreadyConnected(pub SocketAddr);
 
 /// Another connection can be accepted after a non-fatal error
+#[allow(clippy::duplicated_attributes)]
 #[derive(transitive::Transitive)]
 #[fatality(splitable)]
 #[transitive(

--- a/lib/net/peer/error.rs
+++ b/lib/net/peer/error.rs
@@ -119,6 +119,7 @@ pub(in crate::net::peer) mod channel_pool {
         Request(#[source] tokio::task::JoinError),
     }
 
+    #[allow(clippy::duplicated_attributes)]
     #[derive(transitive::Transitive, Debug, Error)]
     #[transitive(
         from(super::connection::SendHeartbeat, super::connection::SendMessage),
@@ -167,6 +168,7 @@ pub(in crate::net::peer) mod request_queue {
     #[error("Failed to add request to send queue")]
     pub struct SendRequest;
 
+    #[allow(clippy::duplicated_attributes)]
     #[derive(transitive::Transitive, Debug, Error)]
     #[transitive(
         from(super::channel_pool::SendMessage, super::channel_pool::Error),

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -99,19 +99,19 @@ fn connect_tip_(
     two_way_peg_data: &mainchain::TwoWayPegData,
 ) -> Result<(), Error> {
     let block_hash = header.hash();
-    let _fees: bitcoin::Amount = state.validate_block(rwtxn, header, body)?;
+    // Use optimised prevalidation + connect path to avoid recomputation
     let orchard_frontier = if tracing::enabled!(tracing::Level::DEBUG) {
         let merkle_root = body.compute_merkle_root();
         let height = state.try_get_height(rwtxn).map_err(state::Error::from)?;
         let orchard_frontier = state
-            .connect_block(rwtxn, header, body)
+            .apply_block(rwtxn, header, body)
             .map_err(state::Error::from)?;
         tracing::debug!(?height, %merkle_root, %block_hash,
                             "connected body");
         orchard_frontier
     } else {
         state
-            .connect_block(rwtxn, header, body)
+            .apply_block(rwtxn, header, body)
             .map_err(state::Error::from)?
     };
     if let Some(orchard_frontier) = orchard_frontier {

--- a/lib/state/block.rs
+++ b/lib/state/block.rs
@@ -1,19 +1,23 @@
 //! Connect and disconnect blocks
 
-use std::collections::HashSet;
-
+use rayon::prelude::*;
 use rustreexo::accumulator::node_hash::BitcoinNodeHash;
 use sneed::{RoTxn, RwTxn};
 
 use crate::{
-    state::{Error, State, error},
+    state::{Error, PrevalidatedBlock, State, error},
     types::{
         Accumulator, AccumulatorDiff, AmountOverflowError, Body, GetValue as _,
-        Header, InPoint, OutPoint, PointedOutput, SpentOutput, Transaction,
-        orchard,
+        Header, InPoint, OutPoint, OutPointKey, Output, PointedOutput,
+        SpentOutput, Transaction, orchard,
     },
     wallet::Authorization,
 };
+
+/// Calculate total number of inputs across all transactions in a block body
+fn calculate_total_inputs(body: &Body) -> usize {
+    body.transactions.iter().map(|t| t.inputs.len()).sum()
+}
 
 pub fn validate(
     state: &State,
@@ -64,21 +68,35 @@ pub fn validate(
         accumulator_diff.insert((&pointed_output).into());
     }
     let mut total_fees = bitcoin::Amount::ZERO;
-    let mut spent_utxos = HashSet::new();
     let filled_transactions: Vec<_> = body
         .transactions
         .iter()
         .map(|t| state.fill_transaction(rotxn, t))
         .collect::<Result<_, _>>()?;
+    let total_inputs = calculate_total_inputs(body);
+
+    // Collect all inputs as fixed-width keys for efficient double-spend detection via sort-and-scan
+    let mut all_input_keys = Vec::with_capacity(total_inputs);
+    for filled_transaction in &filled_transactions {
+        for (outpoint, _) in &filled_transaction.transaction.inputs {
+            all_input_keys.push(OutPointKey::from_outpoint(outpoint));
+        }
+    }
+
+    // Sort and check for duplicate outpoints (double-spend detection)
+    all_input_keys.par_sort_unstable();
+    if all_input_keys.windows(2).any(|w| w[0] == w[1]) {
+        return Err(Error::UtxoDoubleSpent);
+    }
+
+    // Process transactions for utreexo and fee validation
     for filled_transaction in &filled_transactions {
         let txid = filled_transaction.transaction.txid();
         // hashes of spent utxos, used to verify the utreexo proof
-        let mut spent_utxo_hashes = Vec::<BitcoinNodeHash>::new();
-        for (outpoint, utxo_hash) in &filled_transaction.transaction.inputs {
-            if spent_utxos.contains(outpoint) {
-                return Err(Error::UtxoDoubleSpent);
-            }
-            spent_utxos.insert(*outpoint);
+        let mut spent_utxo_hashes = Vec::<BitcoinNodeHash>::with_capacity(
+            filled_transaction.transaction.inputs.len(),
+        );
+        for (_outpoint, utxo_hash) in &filled_transaction.transaction.inputs {
             spent_utxo_hashes.push(utxo_hash.into());
             accumulator_diff.remove(utxo_hash.into());
         }
@@ -129,6 +147,259 @@ pub fn validate(
     Ok(total_fees)
 }
 
+pub fn prevalidate(
+    state: &State,
+    rotxn: &RoTxn,
+    header: &Header,
+    body: &Body,
+) -> Result<PrevalidatedBlock, Error> {
+    let tip_hash = state.try_get_tip(rotxn)?;
+    if header.prev_side_hash != tip_hash {
+        let err = error::InvalidHeader::PrevSideHash {
+            expected: tip_hash,
+            received: header.prev_side_hash,
+        };
+        return Err(Error::InvalidHeader(err));
+    };
+    let height = state.try_get_height(rotxn)?.map_or(0, |height| height + 1);
+    if body.authorizations.len() > State::body_sigops_limit(height) {
+        return Err(Error::TooManySigops);
+    }
+    let body_size =
+        borsh::object_length(&body).map_err(Error::BorshSerialize)?;
+    if body_size > State::body_size_limit(height) {
+        return Err(Error::BodyTooLarge);
+    }
+    let mut accumulator = state.utreexo_accumulator.get(rotxn, &())?;
+    let mut accumulator_diff = AccumulatorDiff::default();
+    let mut coinbase_value = bitcoin::Amount::ZERO;
+    let merkle_root = body.compute_merkle_root();
+    if merkle_root != header.merkle_root {
+        let err = error::InvalidBody {
+            expected: merkle_root,
+            computed: header.merkle_root,
+        };
+        return Err(Error::InvalidBody(err));
+    }
+    for (vout, output) in body.coinbase.iter().enumerate() {
+        coinbase_value = coinbase_value
+            .checked_add(output.get_value())
+            .ok_or(AmountOverflowError)?;
+        let outpoint = OutPoint::Coinbase {
+            merkle_root,
+            vout: vout as u32,
+        };
+        let pointed_output = PointedOutput {
+            outpoint,
+            output: output.clone(),
+        };
+        accumulator_diff.insert((&pointed_output).into());
+    }
+    let mut total_fees = bitcoin::Amount::ZERO;
+    let filled_transactions: Vec<_> = body
+        .transactions
+        .iter()
+        .map(|t| state.fill_transaction(rotxn, t))
+        .collect::<Result<_, _>>()?;
+    let total_inputs = calculate_total_inputs(body);
+
+    // Collect all inputs as fixed-width keys for efficient double-spend detection via sort-and-scan
+    let mut all_input_keys = Vec::with_capacity(total_inputs);
+    for filled_transaction in &filled_transactions {
+        for (outpoint, _) in &filled_transaction.transaction.inputs {
+            all_input_keys.push(OutPointKey::from_outpoint(outpoint));
+        }
+    }
+
+    // Sort and check for duplicate outpoints (double-spend detection)
+    all_input_keys.par_sort_unstable();
+    if all_input_keys.windows(2).any(|w| w[0] == w[1]) {
+        return Err(Error::UtxoDoubleSpent);
+    }
+
+    // Process transactions for utreexo and fee validation
+    for filled_transaction in &filled_transactions {
+        let txid = filled_transaction.transaction.txid();
+        // hashes of spent utxos, used to verify the utreexo proof
+        let mut spent_utxo_hashes = Vec::<BitcoinNodeHash>::with_capacity(
+            filled_transaction.transaction.inputs.len(),
+        );
+        for (_outpoint, utxo_hash) in &filled_transaction.transaction.inputs {
+            spent_utxo_hashes.push(utxo_hash.into());
+            accumulator_diff.remove(utxo_hash.into());
+        }
+        for (vout, output) in
+            filled_transaction.transaction.outputs.iter().enumerate()
+        {
+            let outpoint = OutPoint::Regular {
+                txid,
+                vout: vout as u32,
+            };
+            let pointed_output = PointedOutput {
+                outpoint,
+                output: output.clone(),
+            };
+            accumulator_diff.insert((&pointed_output).into());
+        }
+        total_fees = total_fees
+            .checked_add(state.validate_filled_transaction(filled_transaction)?)
+            .ok_or(AmountOverflowError)?;
+        // verify utreexo proof
+        if !accumulator
+            .verify(&filled_transaction.transaction.proof, &spent_utxo_hashes)?
+        {
+            return Err(Error::UtreexoProofFailed { txid });
+        }
+    }
+    if coinbase_value > total_fees {
+        return Err(Error::NotEnoughFees);
+    }
+    let spent_utxos = filled_transactions
+        .iter()
+        .flat_map(|t| t.spent_utxos.iter());
+    for (authorization, spent_utxo) in
+        body.authorizations.iter().zip(spent_utxos)
+    {
+        if authorization.get_address() != spent_utxo.address {
+            return Err(Error::WrongPubKeyForAddress);
+        }
+    }
+    if Authorization::verify_body(body).is_err() {
+        return Err(Error::AuthorizationError);
+    }
+    let () = accumulator.apply_diff(accumulator_diff.clone())?;
+    let roots: Vec<BitcoinNodeHash> = accumulator.get_roots();
+    if roots != header.roots {
+        return Err(Error::UtreexoRootsMismatch);
+    }
+    Ok(PrevalidatedBlock {
+        filled_transactions,
+        computed_merkle_root: merkle_root,
+        total_fees,
+        coinbase_value,
+        next_height: height,
+        accumulator_diff,
+    })
+}
+
+pub fn connect_prevalidated(
+    state: &State,
+    rwtxn: &mut RwTxn,
+    header: &Header,
+    body: &Body,
+    prevalidated: PrevalidatedBlock,
+) -> Result<Option<orchard::Frontier>, error::ConnectBlock> {
+    let merkle_root = prevalidated.computed_merkle_root;
+
+    let mut accumulator = state.utreexo_accumulator.get(rwtxn, &())?;
+    let accumulator_diff = prevalidated.accumulator_diff;
+
+    let mut frontier = state
+        .orchard
+        .frontier()
+        .get(rwtxn, &())
+        .map_err(error::Orchard::from)?;
+
+    // Coalesce UTXO/STXO mutations for sorted application
+    use rayon::prelude::*;
+    let mut utxo_deletes: Vec<OutPointKey> = Vec::new();
+    let mut stxo_puts: Vec<(OutPointKey, SpentOutput)> = Vec::new();
+    let mut utxo_puts: Vec<(OutPointKey, Output)> = Vec::new();
+
+    // Collect coinbase UTXOs
+    for (vout, output) in body.coinbase.iter().enumerate() {
+        let outpoint = OutPoint::Coinbase {
+            merkle_root,
+            vout: vout as u32,
+        };
+        let key = OutPointKey::from_outpoint(&outpoint);
+        utxo_puts.push((key, output.clone()));
+    }
+
+    // Collect TX mutations
+    for filled_transaction in &prevalidated.filled_transactions {
+        let txid = filled_transaction.transaction.txid();
+
+        // Inputs: delete UTXOs and create STXOs
+        for (vin, (outpoint, _utxo_hash)) in
+            filled_transaction.transaction.inputs.iter().enumerate()
+        {
+            let spent_utxo = &filled_transaction.spent_utxos[vin];
+            let key = OutPointKey::from_outpoint(outpoint);
+            utxo_deletes.push(key);
+            stxo_puts.push((
+                key,
+                SpentOutput {
+                    output: spent_utxo.clone(),
+                    inpoint: InPoint::Regular {
+                        txid,
+                        vin: vin as u32,
+                    },
+                },
+            ));
+        }
+
+        // Outputs: create UTXOs
+        for (vout, output) in
+            filled_transaction.transaction.outputs.iter().enumerate()
+        {
+            let outpoint = OutPoint::Regular {
+                txid,
+                vout: vout as u32,
+            };
+            let key = OutPointKey::from_outpoint(&outpoint);
+            utxo_puts.push((key, output.clone()));
+        }
+
+        // Handle orchard bundle if present
+        if let Some(orchard_bundle) =
+            filled_transaction.transaction.orchard_bundle.as_ref()
+        {
+            let () =
+                connect_orchard(state, rwtxn, orchard_bundle, &mut frontier)
+                    .map_err(|err| error::ConnectBlock::ConnectTransaction {
+                        txid,
+                        source: error::ConnectTransaction::Orchard(err),
+                    })?;
+        }
+    }
+
+    // Sort operations by key to improve B+tree locality
+    utxo_deletes.par_sort_unstable();
+    stxo_puts.par_sort_unstable_by_key(|(k, _)| *k);
+    utxo_puts.par_sort_unstable_by_key(|(k, _)| *k);
+
+    // Apply deletes first
+    for key in &utxo_deletes {
+        let _ = state.utxos.delete(rwtxn, key)?;
+    }
+    // Then STXO puts
+    for (key, spent_output) in &stxo_puts {
+        state.stxos.put(rwtxn, key, spent_output)?;
+    }
+    // Finally UTXO puts
+    for (key, output) in &utxo_puts {
+        state.utxos.put(rwtxn, key, output)?;
+    }
+
+    // Update tip and height using precomputed values (no redundant DB reads)
+    let block_hash = header.hash();
+    state.tip.put(rwtxn, &(), &block_hash)?;
+    state.height.put(rwtxn, &(), &prevalidated.next_height)?;
+
+    // Apply accumulator diff and update orchard state
+    let () = accumulator.apply_diff(accumulator_diff)?;
+    state.utreexo_accumulator.put(rwtxn, &(), &accumulator)?;
+    let () = state.orchard.put_frontier(rwtxn, &frontier)?;
+    let root_changed: bool = state.orchard.put_historical_root(
+        rwtxn,
+        block_hash,
+        frontier.root(),
+    )?;
+    let res = if root_changed { Some(frontier) } else { None };
+    Ok(res)
+}
+
 /// Connect the orchard components of a transaction
 fn connect_orchard(
     state: &State,
@@ -165,12 +436,16 @@ fn connect_transaction(
 ) -> Result<(), error::ConnectTransaction> {
     let txid = transaction.txid();
     for (vin, (outpoint, utxo_hash)) in transaction.inputs.iter().enumerate() {
-        let spent_output =
-            state.utxos.try_get(rwtxn, outpoint)?.ok_or(error::NoUtxo {
+        let spent_output = state
+            .utxos
+            .try_get(rwtxn, &OutPointKey::from_outpoint(outpoint))?
+            .ok_or(error::NoUtxo {
                 outpoint: *outpoint,
             })?;
         accumulator_diff.remove(utxo_hash.into());
-        state.utxos.delete(rwtxn, outpoint)?;
+        state
+            .utxos
+            .delete(rwtxn, &OutPointKey::from_outpoint(outpoint))?;
         let spent_output = SpentOutput {
             output: spent_output,
             inpoint: InPoint::Regular {
@@ -178,7 +453,11 @@ fn connect_transaction(
                 vin: vin as u32,
             },
         };
-        state.stxos.put(rwtxn, outpoint, &spent_output)?;
+        state.stxos.put(
+            rwtxn,
+            &OutPointKey::from_outpoint(outpoint),
+            &spent_output,
+        )?;
     }
     for (vout, output) in transaction.outputs.iter().enumerate() {
         let outpoint = OutPoint::Regular {
@@ -190,7 +469,8 @@ fn connect_transaction(
             output: output.clone(),
         };
         accumulator_diff.insert((&pointed_output).into());
-        state.utxos.put(rwtxn, &outpoint, output)?;
+        let key = OutPointKey::from_outpoint(&outpoint);
+        state.utxos.put(rwtxn, &key, output)?;
     }
     if let Some(orchard_bundle) = transaction.orchard_bundle.as_ref() {
         let () = connect_orchard(state, rwtxn, orchard_bundle, frontier)?;
@@ -239,7 +519,8 @@ pub fn connect(
             output: output.clone(),
         };
         accumulator_diff.insert((&pointed_output).into());
-        state.utxos.put(rwtxn, &outpoint, output)?;
+        let key = OutPointKey::from_outpoint(&outpoint);
+        state.utxos.put(rwtxn, &key, output)?;
     }
     for transaction in &body.transactions {
         let () = connect_transaction(
@@ -307,7 +588,10 @@ fn disconnect_transaction(
                 output: output.clone(),
             };
             accumulator_diff.remove((&pointed_output).into());
-            if state.utxos.delete(rwtxn, &outpoint)? {
+            if state
+                .utxos
+                .delete(rwtxn, &OutPointKey::from_outpoint(&outpoint))?
+            {
                 Ok::<_, Error>(())
             } else {
                 Err(error::NoUtxo { outpoint }.into())
@@ -320,10 +604,19 @@ fn disconnect_transaction(
         .iter()
         .rev()
         .try_for_each(|(outpoint, utxo_hash)| {
-            if let Some(spent_output) = state.stxos.try_get(rwtxn, outpoint)? {
+            if let Some(spent_output) = state
+                .stxos
+                .try_get(rwtxn, &OutPointKey::from_outpoint(outpoint))?
+            {
                 accumulator_diff.insert(utxo_hash.into());
-                state.stxos.delete(rwtxn, outpoint)?;
-                state.utxos.put(rwtxn, outpoint, &spent_output.output)?;
+                state
+                    .stxos
+                    .delete(rwtxn, &OutPointKey::from_outpoint(outpoint))?;
+                state.utxos.put(
+                    rwtxn,
+                    &OutPointKey::from_outpoint(outpoint),
+                    &spent_output.output,
+                )?;
                 Ok(())
             } else {
                 Err(Error::NoStxo {
@@ -379,7 +672,10 @@ pub fn disconnect_tip(
                 output: output.clone(),
             };
             accumulator_diff.remove((&pointed_output).into());
-            if state.utxos.delete(rwtxn, &outpoint)? {
+            if state
+                .utxos
+                .delete(rwtxn, &OutPointKey::from_outpoint(&outpoint))?
+            {
                 Ok::<_, Error>(())
             } else {
                 Err(error::NoUtxo { outpoint }.into())

--- a/lib/state/error.rs
+++ b/lib/state/error.rs
@@ -32,6 +32,7 @@ pub enum InvalidHeader {
     },
 }
 
+#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Transitive)]
 #[transitive(from(db::Delete, db::Error))]
 #[transitive(from(db::Get, db::Error))]
@@ -65,6 +66,7 @@ pub struct NoUtxo {
     pub outpoint: OutPoint,
 }
 
+#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Transitive)]
 #[transitive(from(db::Delete, db::Error))]
 #[transitive(from(db::Put, db::Error))]
@@ -76,6 +78,8 @@ pub enum ConnectTransaction {
     NoUtxo(#[from] NoUtxo),
     #[error("Orchard error")]
     Orchard(#[from] Orchard),
+    #[error("Utreexo proof verification failed")]
+    UtreexoProofFailed,
 }
 
 impl From<db::Error> for ConnectTransaction {
@@ -84,7 +88,9 @@ impl From<db::Error> for ConnectTransaction {
     }
 }
 
+#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Transitive)]
+#[transitive(from(db::Delete, db::Error))]
 #[transitive(from(db::Get, db::Error))]
 #[transitive(from(db::Put, db::Error))]
 #[transitive(from(db::TryGet, db::Error))]
@@ -104,6 +110,22 @@ pub enum ConnectBlock {
     Orchard(#[from] Orchard),
     #[error(transparent)]
     Utreexo(#[from] UtreexoError),
+    #[error("failed to verify authorization")]
+    AuthorizationError,
+    #[error("total fees less than coinbase value")]
+    NotEnoughFees,
+    #[error("wrong public key for address")]
+    WrongPubKeyForAddress,
+    #[error("Computed Utreexo roots do not match the header roots")]
+    UtreexoRootsMismatch,
+    #[error("too many sigops")]
+    TooManySigops,
+    #[error("body too large")]
+    BodyTooLarge,
+    #[error("utxo double spent")]
+    UtxoDoubleSpent,
+    #[error("other error: {0}")]
+    Other(Box<crate::state::Error>),
 }
 
 impl From<db::Error> for ConnectBlock {
@@ -112,6 +134,7 @@ impl From<db::Error> for ConnectBlock {
     }
 }
 
+#[allow(clippy::duplicated_attributes)]
 #[derive(Debug, Error, Transitive)]
 #[transitive(
     from(db::Clear, db::Error),

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -12,15 +12,16 @@ use sneed::{
 };
 
 use crate::{
-    authorization::Authorization,
     types::{
         self, Accumulator, AmountOverflowError, AmountUnderflowError,
         AuthorizedTransaction, BlockHash, Body, FilledTransaction, GetValue,
-        Header, InPoint, M6id, OutPoint, Output, PointedOutput, SpentOutput,
-        Transaction, TransparentAddress, VERSION, Version, WithdrawalBundle,
-        WithdrawalBundleStatus, proto::mainchain::TwoWayPegData,
+        Header, InPoint, M6id, MerkleRoot, OutPoint, OutPointKey, Output,
+        PointedOutput, SpentOutput, Transaction, TransparentAddress, VERSION,
+        Version, WithdrawalBundle, WithdrawalBundleStatus,
+        proto::mainchain::TwoWayPegData,
     },
     util::Watchable,
+    wallet::Authorization,
 };
 
 mod block;
@@ -34,6 +35,17 @@ pub use orchard::Orchard;
 use rollback::RollBack;
 
 pub const WITHDRAWAL_BUNDLE_FAILURE_GAP: u32 = 4;
+
+/// Prevalidated block data containing computed values from validation
+/// to avoid redundant computation during connection
+pub struct PrevalidatedBlock {
+    pub filled_transactions: Vec<FilledTransaction>,
+    pub computed_merkle_root: MerkleRoot,
+    pub total_fees: bitcoin::Amount,
+    pub coinbase_value: bitcoin::Amount,
+    pub next_height: u32, // Precomputed next height to avoid DB read in write txn
+    pub accumulator_diff: types::AccumulatorDiff,
+}
 
 /// Information we have regarding a withdrawal bundle
 #[derive(Debug, Deserialize, Serialize)]
@@ -64,9 +76,8 @@ pub struct State {
     tip: DatabaseUnique<UnitKey, SerdeBincode<BlockHash>>,
     /// Current height
     height: DatabaseUnique<UnitKey, SerdeBincode<u32>>,
-    pub utxos: DatabaseUnique<SerdeBincode<OutPoint>, SerdeBincode<Output>>,
-    pub stxos:
-        DatabaseUnique<SerdeBincode<OutPoint>, SerdeBincode<SpentOutput>>,
+    pub utxos: DatabaseUnique<OutPointKey, SerdeBincode<Output>>,
+    pub stxos: DatabaseUnique<OutPointKey, SerdeBincode<SpentOutput>>,
     /// Pending withdrawal bundle and block height
     pub pending_withdrawal_bundle:
         DatabaseUnique<UnitKey, SerdeBincode<(WithdrawalBundle, u32)>>,
@@ -175,7 +186,13 @@ impl State {
         &self,
         rotxn: &RoTxn,
     ) -> Result<HashMap<OutPoint, Output>, db_error::Iter> {
-        let utxos = self.utxos.iter(rotxn)?.collect()?;
+        let utxos = self
+            .utxos
+            .iter(rotxn)?
+            .map(|(outpoint_key, output)| {
+                Ok((OutPoint::from(outpoint_key), output))
+            })
+            .collect()?;
         Ok(utxos)
     }
 
@@ -188,6 +205,9 @@ impl State {
             .utxos
             .iter(rotxn)?
             .filter(|(_, output)| Ok(addresses.contains(&output.address)))
+            .map(|(outpoint_key, output)| {
+                Ok((OutPoint::from(outpoint_key), output))
+            })
             .collect()?;
         Ok(utxos)
     }
@@ -258,8 +278,10 @@ impl State {
     ) -> Result<FilledTransaction, Error> {
         let mut spent_utxos = vec![];
         for (outpoint, _) in &transaction.inputs {
-            let utxo =
-                self.utxos.try_get(txn, outpoint)?.ok_or(error::NoUtxo {
+            let utxo = self
+                .utxos
+                .try_get(txn, &OutPointKey::from_outpoint(outpoint))?
+                .ok_or(error::NoUtxo {
                     outpoint: *outpoint,
                 })?;
             spent_utxos.push(utxo);
@@ -423,7 +445,7 @@ impl State {
             .iter(rotxn)?
             .map_err(|err| DbError::from(err).into())
             .for_each(|(outpoint, output)| {
-                if let OutPoint::Deposit(_) = outpoint {
+                if let OutPoint::Deposit(_) = OutPoint::from(outpoint) {
                     total_deposit_utxo_value = total_deposit_utxo_value
                         .checked_add(output.get_value())
                         .ok_or(AmountOverflowError)?;
@@ -436,7 +458,7 @@ impl State {
             .iter(rotxn)?
             .map_err(|err| DbError::from(err).into())
             .for_each(|(outpoint, spent_output)| {
-                if let OutPoint::Deposit(_) = outpoint {
+                if let OutPoint::Deposit(_) = OutPoint::from(outpoint) {
                     total_deposit_stxo_value = total_deposit_stxo_value
                         .checked_add(spent_output.output.get_value())
                         .ok_or(AmountOverflowError)?;
@@ -476,6 +498,62 @@ impl State {
         body: &Body,
     ) -> Result<Option<types::orchard::Frontier>, error::ConnectBlock> {
         block::connect(self, rwtxn, header, body)
+    }
+
+    pub fn prevalidate_block(
+        &self,
+        rotxn: &RoTxn,
+        header: &Header,
+        body: &Body,
+    ) -> Result<PrevalidatedBlock, Error> {
+        block::prevalidate(self, rotxn, header, body)
+    }
+
+    pub fn connect_prevalidated_block(
+        &self,
+        rwtxn: &mut RwTxn,
+        header: &Header,
+        body: &Body,
+        prevalidated: PrevalidatedBlock,
+    ) -> Result<Option<types::orchard::Frontier>, error::ConnectBlock> {
+        block::connect_prevalidated(self, rwtxn, header, body, prevalidated)
+    }
+
+    pub fn apply_block(
+        &self,
+        rwtxn: &mut RwTxn,
+        header: &Header,
+        body: &Body,
+    ) -> Result<Option<types::orchard::Frontier>, error::ConnectBlock> {
+        let prevalidated = self
+            .prevalidate_block(rwtxn, header, body)
+            .map_err(|err| match err {
+                Error::InvalidHeader(h) => {
+                    error::ConnectBlock::InvalidHeader(h)
+                }
+                Error::TooManySigops => error::ConnectBlock::TooManySigops,
+                Error::BodyTooLarge => error::ConnectBlock::BodyTooLarge,
+                Error::InvalidBody(b) => error::ConnectBlock::InvalidBody(b),
+                Error::UtxoDoubleSpent => error::ConnectBlock::UtxoDoubleSpent,
+                Error::UtreexoProofFailed { txid } => {
+                    error::ConnectBlock::ConnectTransaction {
+                        txid,
+                        source: error::ConnectTransaction::UtreexoProofFailed,
+                    }
+                }
+                Error::NotEnoughFees => error::ConnectBlock::NotEnoughFees,
+                Error::WrongPubKeyForAddress => {
+                    error::ConnectBlock::WrongPubKeyForAddress
+                }
+                Error::AuthorizationError => {
+                    error::ConnectBlock::AuthorizationError
+                }
+                Error::UtreexoRootsMismatch => {
+                    error::ConnectBlock::UtreexoRootsMismatch
+                }
+                other => error::ConnectBlock::Other(Box::new(other)),
+            })?;
+        self.connect_prevalidated_block(rwtxn, header, body, prevalidated)
     }
 
     pub fn disconnect_tip(

--- a/lib/types/mod.rs
+++ b/lib/types/mod.rs
@@ -24,8 +24,8 @@ pub use address::{Address, ShieldedAddress, TransparentAddress};
 pub use hashes::{BlockHash, Hash, M6id, MerkleRoot, Txid, hash};
 pub use transaction::{
     AuthorizedTransaction, Body, Content as OutputContent, FilledTransaction,
-    GetValue, InPoint, OutPoint, Output, PointedOutput, SpentOutput,
-    Transaction,
+    GetValue, InPoint, OutPoint, OutPointKey, Output, PointedOutput,
+    SpentOutput, Transaction,
 };
 
 pub const THIS_SIDECHAIN: u8 = 98;
@@ -312,7 +312,7 @@ impl PartialOrd for AggregatedWithdrawal {
 /// Removing twice will cause one deletion.
 /// Inserting and then removing will have no overall effect,
 /// but a second removal will still cause a deletion.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 #[repr(transparent)]
 pub struct AccumulatorDiff(
     /// `true` indicates insertion, `false` indicates removal.

--- a/lib/types/transaction.rs
+++ b/lib/types/transaction.rs
@@ -1,8 +1,9 @@
 use std::collections::HashMap;
 
 use bitcoin::amount::CheckedSum;
-use borsh::BorshSerialize;
+use borsh::{BorshDeserialize, BorshSerialize};
 use educe::Educe;
+use heed::{BoxedError, BytesDecode, BytesEncode};
 use rustreexo::accumulator::{
     mem_forest::MemForest, node_hash::BitcoinNodeHash, proof::Proof,
 };
@@ -81,8 +82,166 @@ impl std::fmt::Display for OutPoint {
     }
 }
 
+/// Fixed-width lexicographically sortable key for OutPoint
+/// Layout: [tag: u8][id: 32][vout: u32 BE]
+/// - tag: 0 = Regular, 1 = Coinbase, 2 = Deposit
+/// - id: txid/merkle_root/bitcoin::txid
+/// - vout: big-endian for numeric order = lexicographic order
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct OutPointKey([u8; 37]);
+
+impl OutPointKey {
+    /// Encode an OutPoint into a fixed-width lexicographically sortable key
+    #[inline]
+    pub fn from_outpoint(op: &OutPoint) -> Self {
+        let mut k = [0u8; 37];
+        match *op {
+            OutPoint::Regular {
+                txid: Txid(id),
+                vout,
+            } => {
+                k[0] = 0;
+                k[1..33].copy_from_slice(&id);
+                k[33..37].copy_from_slice(&vout.to_be_bytes());
+            }
+            OutPoint::Coinbase { merkle_root, vout } => {
+                k[0] = 1;
+                let id: Hash = merkle_root.into();
+                k[1..33].copy_from_slice(&id);
+                k[33..37].copy_from_slice(&vout.to_be_bytes());
+            }
+            OutPoint::Deposit(ref bop) => {
+                k[0] = 2;
+                k[1..33].copy_from_slice(bop.txid.as_ref());
+                k[33..37].copy_from_slice(&bop.vout.to_be_bytes());
+            }
+        }
+        Self(k)
+    }
+
+    /// Get the raw key bytes
+    #[inline]
+    pub fn as_bytes(&self) -> &[u8; 37] {
+        &self.0
+    }
+
+    /// Decode OutPointKey back to OutPoint
+    #[inline]
+    pub fn to_outpoint(&self) -> OutPoint {
+        let tag = self.0[0];
+        let mut id = [0u8; 32];
+        id.copy_from_slice(&self.0[1..33]);
+        let vout = u32::from_be_bytes([
+            self.0[33], self.0[34], self.0[35], self.0[36],
+        ]);
+
+        match tag {
+            0 => OutPoint::Regular {
+                txid: Txid(id),
+                vout,
+            },
+            1 => OutPoint::Coinbase {
+                merkle_root: MerkleRoot::from(Hash::from(id)),
+                vout,
+            },
+            2 => {
+                use bitcoin::hashes::Hash as BitcoinHash;
+                let txid = bitcoin::Txid::from_byte_array(id);
+                OutPoint::Deposit(bitcoin::OutPoint { txid, vout })
+            }
+            _ => unreachable!("Invalid OutPointKey tag"),
+        }
+    }
+}
+
+impl From<OutPoint> for OutPointKey {
+    #[inline]
+    fn from(op: OutPoint) -> Self {
+        Self::from_outpoint(&op)
+    }
+}
+
+impl From<&OutPoint> for OutPointKey {
+    #[inline]
+    fn from(op: &OutPoint) -> Self {
+        Self::from_outpoint(op)
+    }
+}
+
+impl From<OutPointKey> for OutPoint {
+    #[inline]
+    fn from(key: OutPointKey) -> Self {
+        key.to_outpoint()
+    }
+}
+
+impl From<&OutPointKey> for OutPoint {
+    #[inline]
+    fn from(key: &OutPointKey) -> Self {
+        key.to_outpoint()
+    }
+}
+
+impl Ord for OutPointKey {
+    #[inline]
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.0.cmp(&other.0)
+    }
+}
+
+impl PartialOrd for OutPointKey {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl AsRef<[u8]> for OutPointKey {
+    #[inline]
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+// Database key encoding traits for direct LMDB usage
+impl<'a> BytesEncode<'a> for OutPointKey {
+    type EItem = OutPointKey;
+
+    #[inline]
+    fn bytes_encode(
+        item: &'a Self::EItem,
+    ) -> Result<std::borrow::Cow<'a, [u8]>, BoxedError> {
+        Ok(std::borrow::Cow::Borrowed(item.as_ref()))
+    }
+}
+
+impl<'a> BytesDecode<'a> for OutPointKey {
+    type DItem = OutPointKey;
+
+    #[inline]
+    fn bytes_decode(bytes: &'a [u8]) -> Result<Self::DItem, BoxedError> {
+        if bytes.len() != 37 {
+            return Err("OutPointKey must be exactly 37 bytes".into());
+        }
+        let mut key = [0u8; 37];
+        key.copy_from_slice(bytes);
+        Ok(OutPointKey(key))
+    }
+}
+
 /// Reference to a tx input.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Clone,
+    Copy,
+    Debug,
+    Deserialize,
+    Eq,
+    Hash,
+    PartialEq,
+    Serialize,
+)]
 pub enum InPoint {
     /// Transaction input
     Regular {
@@ -94,31 +253,6 @@ pub enum InPoint {
     Withdrawal {
         m6id: M6id,
     },
-}
-
-fn borsh_serialize_bitcoin_amount<W>(
-    bitcoin_amount: &bitcoin::Amount,
-    writer: &mut W,
-) -> borsh::io::Result<()>
-where
-    W: borsh::io::Write,
-{
-    borsh::BorshSerialize::serialize(&bitcoin_amount.to_sat(), writer)
-}
-
-fn borsh_serialize_bitcoin_address<V, W>(
-    bitcoin_address: &bitcoin::Address<V>,
-    writer: &mut W,
-) -> borsh::io::Result<()>
-where
-    V: bitcoin::address::NetworkValidation,
-    W: borsh::io::Write,
-{
-    let spk = bitcoin_address
-        .as_unchecked()
-        .assume_checked_ref()
-        .script_pubkey();
-    borsh::BorshSerialize::serialize(spk.as_bytes(), writer)
 }
 
 mod content {
@@ -163,20 +297,146 @@ mod content {
         serde_with::FromInto<HumanReadableRepr>,
     >;
 
-    #[derive(borsh::BorshSerialize, Clone, Debug, Eq, PartialEq)]
+    #[derive(Clone, Debug, Eq, PartialEq)]
     pub enum Content {
-        Value(
-            #[borsh(serialize_with = "super::borsh_serialize_bitcoin_amount")]
-            bitcoin::Amount,
-        ),
+        Value(bitcoin::Amount),
         Withdrawal {
-            #[borsh(serialize_with = "super::borsh_serialize_bitcoin_amount")]
             value: bitcoin::Amount,
-            #[borsh(serialize_with = "super::borsh_serialize_bitcoin_amount")]
             main_fee: bitcoin::Amount,
-            #[borsh(serialize_with = "super::borsh_serialize_bitcoin_address")]
             main_address: bitcoin::Address<bitcoin::address::NetworkUnchecked>,
         },
+    }
+
+    impl borsh::BorshSerialize for Content {
+        fn serialize<W: borsh::io::Write>(
+            &self,
+            writer: &mut W,
+        ) -> borsh::io::Result<()> {
+            match self {
+                Content::Value(amount) => {
+                    borsh::BorshSerialize::serialize(&0u8, writer)?;
+                    borsh::BorshSerialize::serialize(&amount.to_sat(), writer)
+                }
+                Content::Withdrawal {
+                    value,
+                    main_fee,
+                    main_address,
+                } => {
+                    borsh::BorshSerialize::serialize(&1u8, writer)?;
+                    borsh::BorshSerialize::serialize(&value.to_sat(), writer)?;
+                    borsh::BorshSerialize::serialize(
+                        &main_fee.to_sat(),
+                        writer,
+                    )?;
+                    // Serialize address as script bytes
+                    let script = main_address
+                        .as_unchecked()
+                        .assume_checked_ref()
+                        .script_pubkey();
+                    borsh::BorshSerialize::serialize(&script.as_bytes(), writer)
+                }
+            }
+        }
+    }
+
+    impl borsh::BorshDeserialize for Content {
+        fn deserialize(buf: &mut &[u8]) -> borsh::io::Result<Self> {
+            let variant: u8 = borsh::BorshDeserialize::deserialize(buf)?;
+            match variant {
+                0 => {
+                    let sats: u64 = borsh::BorshDeserialize::deserialize(buf)?;
+                    Ok(Content::Value(bitcoin::Amount::from_sat(sats)))
+                }
+                1 => {
+                    let value_sats: u64 =
+                        borsh::BorshDeserialize::deserialize(buf)?;
+                    let main_fee_sats: u64 =
+                        borsh::BorshDeserialize::deserialize(buf)?;
+                    let script_bytes: Vec<u8> =
+                        borsh::BorshDeserialize::deserialize(buf)?;
+
+                    let script = bitcoin::ScriptBuf::from_bytes(script_bytes);
+                    let checked_address = bitcoin::Address::from_script(
+                        &script,
+                        bitcoin::Network::Bitcoin,
+                    )
+                    .map_err(|e| {
+                        borsh::io::Error::new(
+                            borsh::io::ErrorKind::InvalidData,
+                            e,
+                        )
+                    })?;
+                    let address = checked_address.as_unchecked().clone();
+
+                    Ok(Content::Withdrawal {
+                        value: bitcoin::Amount::from_sat(value_sats),
+                        main_fee: bitcoin::Amount::from_sat(main_fee_sats),
+                        main_address: address,
+                    })
+                }
+                _ => Err(borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
+                    format!("Invalid Content variant: {}", variant),
+                )),
+            }
+        }
+
+        fn deserialize_reader<R: borsh::io::Read>(
+            reader: &mut R,
+        ) -> borsh::io::Result<Self> {
+            let mut variant_buf = [0u8; 1];
+            reader.read_exact(&mut variant_buf)?;
+            let variant = variant_buf[0];
+
+            match variant {
+                0 => {
+                    let mut sats_buf = [0u8; 8];
+                    reader.read_exact(&mut sats_buf)?;
+                    let sats = u64::from_le_bytes(sats_buf);
+                    Ok(Content::Value(bitcoin::Amount::from_sat(sats)))
+                }
+                1 => {
+                    let mut value_buf = [0u8; 8];
+                    reader.read_exact(&mut value_buf)?;
+                    let value_sats = u64::from_le_bytes(value_buf);
+
+                    let mut fee_buf = [0u8; 8];
+                    reader.read_exact(&mut fee_buf)?;
+                    let main_fee_sats = u64::from_le_bytes(fee_buf);
+
+                    // Read script length first
+                    let mut len_buf = [0u8; 4];
+                    reader.read_exact(&mut len_buf)?;
+                    let script_len = u32::from_le_bytes(len_buf) as usize;
+
+                    let mut script_bytes = vec![0u8; script_len];
+                    reader.read_exact(&mut script_bytes)?;
+
+                    let script = bitcoin::ScriptBuf::from_bytes(script_bytes);
+                    let checked_address = bitcoin::Address::from_script(
+                        &script,
+                        bitcoin::Network::Bitcoin,
+                    )
+                    .map_err(|e| {
+                        borsh::io::Error::new(
+                            borsh::io::ErrorKind::InvalidData,
+                            e,
+                        )
+                    })?;
+                    let address = checked_address.as_unchecked().clone();
+
+                    Ok(Content::Withdrawal {
+                        value: bitcoin::Amount::from_sat(value_sats),
+                        main_fee: bitcoin::Amount::from_sat(main_fee_sats),
+                        main_address: address,
+                    })
+                }
+                _ => Err(borsh::io::Error::new(
+                    borsh::io::ErrorKind::InvalidData,
+                    format!("Invalid Content variant: {}", variant),
+                )),
+            }
+        }
     }
 
     impl Content {
@@ -307,6 +567,7 @@ mod content {
 pub use content::Content;
 
 #[derive(
+    BorshDeserialize,
     BorshSerialize,
     Clone,
     Debug,
@@ -385,24 +646,35 @@ where
     Auth: BundleAuthorization,
 {
     pub fn txid(&self) -> Txid {
+        use smallvec::SmallVec;
+        thread_local! {
+            static SCRATCH: std::cell::RefCell<SmallVec<[u8; 512]>> =
+                std::cell::RefCell::new(SmallVec::new());
+        }
         let Self {
             inputs,
             proof: _,
             outputs,
             orchard_bundle,
         } = self;
-        let canonical_bytes: Vec<u8> = {
-            || {
-                let mut bytes = borsh::to_vec(inputs)?;
-                BorshSerialize::serialize(&outputs, &mut bytes)?;
-                if let Some(orchard_bundle) = orchard_bundle {
-                    orchard_bundle.borsh_serialize_without_auth(&mut bytes)?;
-                }
-                std::io::Result::Ok(bytes)
+        let hash = SCRATCH.with(|cell| {
+            let mut buf = cell.borrow_mut();
+            buf.clear();
+            // Inputs
+            borsh::to_writer(&mut *buf, inputs)
+                .expect("failed to serialize with borsh to compute a hash");
+            // Outputs
+            BorshSerialize::serialize(&outputs, &mut *buf)
+                .expect("failed to serialize with borsh to compute a hash");
+            // Orchard bundle without auth
+            if let Some(orchard_bundle) = orchard_bundle {
+                orchard_bundle
+                    .borsh_serialize_without_auth(&mut *buf)
+                    .expect("failed to serialize with borsh to compute a hash");
             }
-        }()
-        .expect("failed to serialize with borsh to compute a hash");
-        Txid(blake3::hash(&canonical_bytes).into())
+            blake3::hash(&buf).into()
+        });
+        Txid(hash)
     }
 }
 
@@ -436,7 +708,16 @@ where
 }
 
 /// Representation of a spent output
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(
+    BorshDeserialize,
+    BorshSerialize,
+    Clone,
+    Debug,
+    Deserialize,
+    Eq,
+    PartialEq,
+    Serialize,
+)]
 pub struct SpentOutput {
     pub output: Output,
     pub inpoint: InPoint,
@@ -539,7 +820,11 @@ impl Body {
 
     pub fn compute_merkle_root(&self) -> MerkleRoot {
         // FIXME: Compute actual merkle root instead of just a hash.
-        hash(&(&self.coinbase, &self.transactions)).into()
+        crate::types::hashes::hash_with_scratch_buffer(&(
+            &self.coinbase,
+            &self.transactions,
+        ))
+        .into()
     }
 
     // Modifies the memforest, without checking tx proofs


### PR DESCRIPTION
This PR adds misc perf improvements which have been already merged (or partially merged) into upstream.
This includes
- Prevalidate + connect + apply in single RW txn:
- LMDB env fast flags in node init (`WRITE_MAP, MAP_ASYNC, NO_SYNC, NO_META_SYNC, NO_READ_AHEAD, NO_TLS`)
- Vec + parallel sort over `OutPointKey` and ordered apply to coalesce writes
- Fixed-width `OutPointKey keys` for LMDB
- Double-spend detection via parallel sort of fixed-width keys
- Vector preallocations / more rayon usage
- Switch to `mimalloc` v3 as a global allocator
- Scratch-buffer hashing on hot call sites