### PR TITLE
Fix melt cast fee fingerprint

### DIFF
--- a/app/gui/coins/melt_cast.rs
+++ b/app/gui/coins/melt_cast.rs
@@ -26,7 +26,6 @@ struct MeltSelectUtxosInner {
 }
 
 struct MeltSelectUtxos {
-    fee_input: String,
     inner: Option<Result<Box<MeltSelectUtxosInner>, String>>,
     utxo_selector: UtxoSelector,
     selected_utxos: HashMap<OutPoint, Output>,
@@ -35,7 +34,6 @@ struct MeltSelectUtxos {
 impl MeltSelectUtxos {
     pub fn new(app: Option<&App>) -> Self {
         let mut this = Self {
-            fee_input: String::new(),
             inner: None,
             utxo_selector: UtxoSelector::default(),
             selected_utxos: HashMap::default(),
@@ -109,8 +107,8 @@ impl MeltSelectUtxos {
         drop(rt_guard)
     }
 
-    /// Returns `Some(fee)` if melt is clicked
-    fn show(&mut self, ui: &mut egui::Ui) -> InnerResponse<Option<Amount>> {
+    /// Returns `Some(())` if melt is clicked
+    fn show(&mut self, ui: &mut egui::Ui) -> InnerResponse<Option<()>> {
         self.update();
         egui::ScrollArea::horizontal()
             .show(ui, |ui| {
@@ -139,26 +137,22 @@ impl MeltSelectUtxos {
                     });
                 let resp =
                     egui::CentralPanel::default().show_inside(ui, |ui| {
-                        let fee_edit =
-                            egui::TextEdit::singleline(&mut self.fee_input)
-                                .hint_text("fee")
-                                .desired_width(80.);
-                        ui.add(fee_edit);
-                        ui.label("BTC");
-                        let fee = bitcoin::Amount::from_str_in(
-                            &self.fee_input,
-                            bitcoin::Denomination::Bitcoin,
+                        ui.monospace_selectable_singleline(
+                            false,
+                            format!(
+                                "Fee per tx: {}",
+                                show_btc_amount(wallet::STANDARD_FEE)
+                            ),
                         );
                         ui.vertical_centered(|ui| {
                             if ui
                                 .add_enabled(
-                                    fee.is_ok()
-                                        && !self.selected_utxos.is_empty(),
+                                    !self.selected_utxos.is_empty(),
                                     Button::new("Melt"),
                                 )
                                 .clicked()
                             {
-                                Some(fee.unwrap())
+                                Some(())
                             } else {
                                 None
                             }
@@ -179,14 +173,14 @@ struct Melting {
 }
 
 impl Melting {
-    fn new(app: &App, mut melt_batch: MeltBatch, fee: Amount) -> Self {
+    fn new(app: &App, mut melt_batch: MeltBatch) -> Self {
         let _rt_guard = app.runtime.enter();
         let txs = Arc::new(RwLock::new(Vec::new()));
         let fut = Promise::spawn_async({
             let app = app.clone();
             let txs = Arc::clone(&txs);
             async move {
-                while let Some(tx_fn) = melt_batch.next_tx(fee).await? {
+                while let Some(tx_fn) = melt_batch.next_tx().await? {
                     let accumulator = app.node.get_tip_accumulator()?;
                     let tx = tx_fn(&accumulator, &app.wallet)?;
                     let txid = tx.txid();
@@ -229,11 +223,11 @@ impl MeltInner {
     fn show(&mut self, app: Option<&App>, ui: &mut egui::Ui) {
         match self {
             Self::SelectUtxos(select_utxos) => {
-                if let Some(fee) = select_utxos.show(ui).inner {
+                if let Some(()) = select_utxos.show(ui).inner {
                     let selected_utxos =
                         select_utxos.selected_utxos.drain().collect();
                     let melt_batch = MeltBatch::new(selected_utxos);
-                    let melting = Melting::new(app.unwrap(), melt_batch, fee);
+                    let melting = Melting::new(app.unwrap(), melt_batch);
                     *self = Self::Melting(melting);
                 }
             }
@@ -262,16 +256,15 @@ impl Melt {
 #[derive(Debug, Default)]
 struct CastInput {
     amount_input: String,
-    fee_input: String,
 }
 
 impl CastInput {
-    /// Returns `Some((amount, fee_per_cast_tx))` if cast is clicked
+    /// Returns `Some(amount)` if cast is clicked
     fn show(
         &mut self,
         app: Option<&App>,
         ui: &mut egui::Ui,
-    ) -> InnerResponse<Option<(Amount, Amount)>> {
+    ) -> InnerResponse<Option<Amount>> {
         let Some(app) = app else {
             return InnerResponse::new(None, ui.response());
         };
@@ -301,21 +294,16 @@ impl CastInput {
             &self.amount_input,
             bitcoin::Denomination::Bitcoin,
         );
-        let fee_edit = egui::TextEdit::singleline(&mut self.fee_input)
-            .hint_text("fee per cast tx")
-            .desired_width(80.);
-        ui.add(fee_edit);
-        ui.label("BTC");
-        let fee_per_cast_tx = bitcoin::Amount::from_str_in(
-            &self.fee_input,
-            bitcoin::Denomination::Bitcoin,
+        ui.monospace_selectable_singleline(
+            false,
+            format!("Fee per tx: {}", show_btc_amount(wallet::STANDARD_FEE)),
         );
-        let total_fee = match (amount.as_ref(), fee_per_cast_tx.as_ref()) {
-            (Ok(amount), Ok(fee_per_cast_tx)) => fee_per_cast_tx
+        // One transaction per set bit of the amount, each charged the standard
+        // fee.
+        let total_fee = amount.as_ref().ok().and_then(|amount| {
+            wallet::STANDARD_FEE
                 .checked_mul(amount.to_sat().count_ones() as u64)
-                .and_then(|total_fee| amount.checked_add(total_fee)),
-            (_, _) => None,
-        };
+        });
         if let Some(total_fee) = total_fee {
             ui.monospace_selectable_singleline(
                 false,
@@ -336,7 +324,7 @@ impl CastInput {
                 )
                 .clicked()
             {
-                Some((amount.unwrap(), fee_per_cast_tx.unwrap()))
+                Some(amount.unwrap())
             } else {
                 None
             }
@@ -350,14 +338,14 @@ struct Casting {
 }
 
 impl Casting {
-    fn new(app: &App, mut cast: wallet::Cast, fee_per_cast_tx: Amount) -> Self {
+    fn new(app: &App, mut cast: wallet::Cast) -> Self {
         let _rt_guard = app.runtime.enter();
         let txs = Arc::new(RwLock::new(Vec::new()));
         let fut = Promise::spawn_async({
             let app = app.clone();
             let txs = Arc::clone(&txs);
             async move {
-                while let Some(tx_fn) = cast.next_tx(fee_per_cast_tx).await {
+                while let Some(tx_fn) = cast.next_tx().await {
                     let accumulator = app.node.get_tip_accumulator()?;
                     let tx = tx_fn(&accumulator, &app.wallet)?;
                     let txid = tx.txid();
@@ -396,12 +384,9 @@ impl CastInner {
     fn show(&mut self, app: Option<&App>, ui: &mut egui::Ui) {
         match self {
             Self::CastInput(cast_input) => {
-                if let Some((amount, fee_per_cast_tx)) =
-                    cast_input.show(app, ui).inner
-                {
+                if let Some(amount) = cast_input.show(app, ui).inner {
                     let cast = wallet::Cast::new(amount);
-                    let casting =
-                        Casting::new(app.unwrap(), cast, fee_per_cast_tx);
+                    let casting = Casting::new(app.unwrap(), cast);
                     *self = Self::Casting(casting);
                 }
             }

--- a/lib/wallet.rs
+++ b/lib/wallet.rs
@@ -1664,6 +1664,16 @@ impl Watchable<()> for Wallet {
     }
 }
 
+/// Fee used for every melt and cast transaction.
+///
+/// The fee is a fixed, shared constant rather than a user-chosen value. The
+/// fee of a melt/cast transaction is publicly derivable from its value balance
+/// and transparent output, so a per-user fee would be a fingerprint that links
+/// every bill in a cast (or every tx in a melt) together, defeating the
+/// unlinkability that fresh addresses and randomized timing provide. A single
+/// shared constant carries no per-user entropy.
+pub const STANDARD_FEE: Amount = Amount::from_sat(1000);
+
 /// Represents an ongoing cast
 #[derive(Debug)]
 pub struct Cast {
@@ -1674,6 +1684,13 @@ pub struct Cast {
 }
 
 impl Cast {
+    /// Fee charged for every cast transaction. Shared by all users and
+    /// independent of the bill or the amount, so it cannot be used to link
+    /// a cast's bills. See [`STANDARD_FEE`].
+    pub fn tx_fee() -> Amount {
+        STANDARD_FEE
+    }
+
     /// Convert an bill exponent (n in 2^n sats) to the weekday on which a
     /// 2^n sats bill should be withdrawn
     fn bill_exponent_to_weekday(exp: u32) -> chrono::Weekday {
@@ -1740,7 +1757,6 @@ impl Cast {
 
     pub async fn next_tx(
         &mut self,
-        fee: Amount,
     ) -> Option<impl FnOnce(&Accumulator, &Wallet) -> Result<Transaction, Error>>
     {
         let (bill_exponent, ts) =
@@ -1751,6 +1767,7 @@ impl Cast {
                 .unwrap();
         tokio::time::sleep(sleep_duration).await;
         let amount = Amount::from_sat(1 << bill_exponent);
+        let fee = Self::tx_fee();
         let _ = self.bill_exponents_with_timestamps.pop_front().unwrap();
         let res = move |accumulator: &Accumulator, wallet: &Wallet| {
             wallet.create_unshield_transaction(accumulator, amount, fee)
@@ -1796,13 +1813,15 @@ impl MeltBatch {
 
     pub async fn next_tx(
         &mut self,
-        fee: Amount,
     ) -> Result<
         Option<
             impl FnOnce(&Accumulator, &Wallet) -> Result<Transaction, Error>,
         >,
         Error,
     > {
+        // Shared standard fee, not user-chosen, so melt txs cannot be linked
+        // by a per-user fee fingerprint. See [`STANDARD_FEE`].
+        let fee = STANDARD_FEE;
         let Some(((_, output), duration)) = self.utxos_with_duration.front()
         else {
             return Ok(None);

--- a/lib/wallet.rs
+++ b/lib/wallet.rs
@@ -1849,3 +1849,67 @@ impl MeltBatch {
         Ok(Some(res))
     }
 }
+
+#[cfg(test)]
+mod fee_privacy_tests {
+    use super::*;
+
+    fn bill_exponents(cast: &Cast) -> Vec<u32> {
+        cast.bill_exponents_with_timestamps
+            .iter()
+            .map(|(exp, _ts)| *exp)
+            .collect()
+    }
+
+    /// A cast decomposes the amount into power-of-two "bill" denominations
+    /// (one per set bit), with no fee folded into the bill amounts. This keeps
+    /// each bill a standard denomination shared across users.
+    #[test]
+    fn cast_decomposes_into_standard_denominations() {
+        for sats in [1u64, 0b1011, 1_000_000, (1 << 20) + (1 << 5) + 1] {
+            let cast = Cast::new(Amount::from_sat(sats));
+            let mut exps = bill_exponents(&cast);
+            exps.sort_unstable();
+            let expected: Vec<u32> =
+                (0..u64::BITS).filter(|i| (sats >> i) & 1 == 1).collect();
+            assert_eq!(exps, expected, "bills must be the set bits of {sats}");
+            let sum: u64 = exps.iter().map(|exp| 1u64 << exp).sum();
+            assert_eq!(sum, sats, "bills must sum back to the amount");
+        }
+    }
+
+    /// Privacy regression: the fee an observer can derive from a cast
+    /// transaction (value_balance - transparent_output) is the same shared
+    /// `STANDARD_FEE` for every bill and every cast, regardless of the amount.
+    /// A per-user or per-amount fee would be a fingerprint linking a cast's
+    /// bills together. The fee is not a caller-supplied parameter.
+    #[test]
+    fn all_cast_bills_use_the_same_shared_fee() {
+        assert_eq!(Cast::tx_fee(), STANDARD_FEE);
+
+        // Footprint of a bill as seen on chain: an unshield of denomination
+        // `2^exp` has transparent output `2^exp` and value balance
+        // `2^exp + fee`, so the observer-derived fee is exactly the fee used.
+        let observed_fees = |sats: u64| -> Vec<Amount> {
+            let cast = Cast::new(Amount::from_sat(sats));
+            bill_exponents(&cast)
+                .into_iter()
+                .map(|exp| {
+                    let denom = Amount::from_sat(1 << exp);
+                    let value_balance = denom + Cast::tx_fee();
+                    value_balance - denom
+                })
+                .collect()
+        };
+
+        // Different amounts (e.g. two different users), all bills, one fee.
+        for sats in [0b1011u64, 1_000_000, 12_345_678] {
+            for fee in observed_fees(sats) {
+                assert_eq!(
+                    fee, STANDARD_FEE,
+                    "every cast bill must use the shared standard fee"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
The fee is publicly derivable from each transaction. For an unshield, the Orchard `value_balance` (committed in the bundle) equals 2^n + fee and the transparent output 2^n is also public. So any observer computes:

```
fee_i = value_balance_i − transparent_output_i
```

Because all bills in one cast share the identical fee, an observer can cluster every unshield with that same fee value as one cast. This defeats the fresh-address + randomized-timing unlinkability. Once linked, summing the denominations recovers the total cast amount and reveals they belong to a single user. 

MeltBatch has the same issue. Every melt in the batch uses one constant fee and the shield's `value_balance = −(V−fee)` is public, so the melt set is linkable by the shared fee offset too.