### PR TITLE
Fix melt amount fingerprint

### DIFF
--- a/app/gui/coins/melt_cast.rs
+++ b/app/gui/coins/melt_cast.rs
@@ -1,169 +1,95 @@
-use std::{collections::HashMap, sync::Arc, task::Poll};
+use std::sync::Arc;
 
 use bitcoin::Amount;
 use eframe::egui::{self, Button, InnerResponse};
 use parking_lot::RwLock;
 use poll_promise::Promise;
 use thunder_orchard::{
-    types::{OutPoint, Output, Txid},
-    util::Watchable,
-    wallet::{self, MeltBatch, Wallet},
+    types::Txid,
+    wallet::{self, MeltBatch},
 };
 
 use crate::{
     app::App,
     gui::util::{UiExt, show_btc_amount},
-    util::PromiseStream,
 };
 
-use super::utxo_selector::UtxoSelector;
-
-struct MeltSelectUtxosInner {
-    rt_handle: tokio::runtime::Handle,
-    wallet: Box<Wallet>,
-    utxos: HashMap<OutPoint, Output>,
-    wallet_updated: PromiseStream<<Wallet as Watchable<()>>::WatchStream>,
+#[derive(Debug, Default)]
+struct MeltInput {
+    amount_input: String,
 }
 
-struct MeltSelectUtxos {
-    inner: Option<Result<Box<MeltSelectUtxosInner>, String>>,
-    utxo_selector: UtxoSelector,
-    selected_utxos: HashMap<OutPoint, Output>,
-}
-
-impl MeltSelectUtxos {
-    pub fn new(app: Option<&App>) -> Self {
-        let mut this = Self {
-            inner: None,
-            utxo_selector: UtxoSelector::default(),
-            selected_utxos: HashMap::default(),
-        };
+impl MeltInput {
+    /// Returns `Some(amount)` if melt is clicked
+    fn show(
+        &mut self,
+        app: Option<&App>,
+        ui: &mut egui::Ui,
+    ) -> InnerResponse<Option<Amount>> {
         let Some(app) = app else {
-            return this;
+            return InnerResponse::new(None, ui.response());
         };
-        let wallet_updated = {
-            let rt_guard = app.runtime.enter();
-            let wallet_updated = PromiseStream::from(app.wallet.watch());
-            drop(rt_guard);
-            wallet_updated
-        };
-        this.inner = Some('inner: {
-            let wallet_rotxn = match app.wallet.env().read_txn() {
-                Ok(wallet_rotxn) => wallet_rotxn,
-                Err(err) => {
-                    let err_msg = format!("{:#}", anyhow::Error::from(err));
-                    tracing::error!("{err_msg}");
-                    break 'inner Err(err_msg);
-                }
-            };
-            match app.wallet.get_utxos(&wallet_rotxn) {
-                Ok(utxos) => Ok(Box::new(MeltSelectUtxosInner {
-                    rt_handle: app.runtime.handle().clone(),
-                    utxos,
-                    wallet: Box::new(app.wallet.clone()),
-                    wallet_updated,
-                })),
-                Err(err) => {
-                    let err_msg = format!("{:#}", anyhow::Error::from(err));
-                    tracing::error!("{err_msg}");
-                    Err(err_msg)
-                }
+        let transparent_balance = match app.wallet.get_balance() {
+            Ok(balance) => balance.available_transparent,
+            Err(err) => {
+                let err = anyhow::Error::from(err);
+                return InnerResponse::new(
+                    None,
+                    ui.monospace_selectable_multiline(format!("{err:#}")),
+                );
             }
+        };
+        ui.monospace_selectable_singleline(
+            false,
+            format!(
+                "Transparent balance available: {}",
+                show_btc_amount(transparent_balance)
+            ),
+        );
+        let amount_edit = egui::TextEdit::singleline(&mut self.amount_input)
+            .hint_text("melt amount")
+            .desired_width(80.);
+        ui.add(amount_edit);
+        ui.label("BTC");
+        let amount = bitcoin::Amount::from_str_in(
+            &self.amount_input,
+            bitcoin::Denomination::Bitcoin,
+        );
+        ui.monospace_selectable_singleline(
+            false,
+            format!("Fee per tx: {}", show_btc_amount(wallet::STANDARD_FEE)),
+        );
+        // One transaction per set bit of the amount, each charged the standard
+        // fee.
+        let total_fee = amount.as_ref().ok().and_then(|amount| {
+            wallet::STANDARD_FEE
+                .checked_mul(amount.to_sat().count_ones() as u64)
         });
-        this
-    }
-
-    /// Updates values if the wallet has been updated
-    fn update(&mut self) {
-        let Some(Ok(inner)) = self.inner.as_mut() else {
-            return;
-        };
-        let rt_guard = inner.rt_handle.enter();
-        match inner.wallet_updated.poll_next() {
-            Some(Poll::Ready(())) => (),
-            Some(Poll::Pending) | None => return,
+        if let Some(total_fee) = total_fee {
+            ui.monospace_selectable_singleline(
+                false,
+                format!("Total fee: {}", show_btc_amount(total_fee)),
+            );
         }
-        let wallet_env = inner.wallet.env().clone();
-        let wallet_rotxn = match wallet_env.read_txn() {
-            Ok(wallet_rotxn) => wallet_rotxn,
-            Err(err) => {
-                let err_msg = format!("{:#}", anyhow::Error::from(err));
-                tracing::error!("{err_msg}");
-                self.inner = Some(Err(err_msg));
-                return;
-            }
+        let total_spend = match (amount.as_ref(), total_fee.as_ref()) {
+            (Ok(amount), Some(total_fee)) => amount.checked_add(*total_fee),
+            (_, _) => None,
         };
-        match inner.wallet.get_utxos(&wallet_rotxn) {
-            Ok(utxos) => {
-                inner.utxos = utxos;
+        ui.vertical_centered(|ui| {
+            if ui
+                .add_enabled(
+                    total_spend.is_some_and(|total_spend| {
+                        total_spend <= transparent_balance
+                    }),
+                    Button::new("Melt"),
+                )
+                .clicked()
+            {
+                Some(amount.unwrap())
+            } else {
+                None
             }
-            Err(err) => {
-                let err_msg = format!("{:#}", anyhow::Error::from(err));
-                tracing::error!("{err_msg}");
-                self.inner = Some(Err(err_msg));
-                return;
-            }
-        }
-        drop(rt_guard)
-    }
-
-    /// Returns `Some(())` if melt is clicked
-    fn show(&mut self, ui: &mut egui::Ui) -> InnerResponse<Option<()>> {
-        self.update();
-        egui::ScrollArea::horizontal()
-            .show(ui, |ui| {
-                egui::SidePanel::left("spend_utxo")
-                    .exact_width(ui.available_width() / 2.)
-                    .resizable(false)
-                    .show_inside(ui, |ui| {
-                        let utxos = match &self.inner {
-                            Some(Ok(inner)) => Some(&inner.utxos),
-                            Some(Err(_)) | None => None,
-                        };
-                        self.utxo_selector.show(
-                            utxos,
-                            ui,
-                            "Melt UTXOs",
-                            true,
-                            |selected, (outpoint, output)| {
-                                if selected {
-                                    self.selected_utxos
-                                        .insert(outpoint, output);
-                                } else {
-                                    self.selected_utxos.remove(&outpoint);
-                                }
-                            },
-                        );
-                    });
-                let resp =
-                    egui::CentralPanel::default().show_inside(ui, |ui| {
-                        ui.monospace_selectable_singleline(
-                            false,
-                            format!(
-                                "Fee per tx: {}",
-                                show_btc_amount(wallet::STANDARD_FEE)
-                            ),
-                        );
-                        ui.vertical_centered(|ui| {
-                            if ui
-                                .add_enabled(
-                                    !self.selected_utxos.is_empty(),
-                                    Button::new("Melt"),
-                                )
-                                .clicked()
-                            {
-                                Some(())
-                            } else {
-                                None
-                            }
-                        })
-                    });
-                InnerResponse {
-                    inner: resp.inner.inner,
-                    response: resp.response | resp.inner.response,
-                }
-            })
-            .inner
+        })
     }
 }
 
@@ -180,7 +106,7 @@ impl Melting {
             let app = app.clone();
             let txs = Arc::clone(&txs);
             async move {
-                while let Some(tx_fn) = melt_batch.next_tx().await? {
+                while let Some(tx_fn) = melt_batch.next_tx().await {
                     let accumulator = app.node.get_tip_accumulator()?;
                     let tx = tx_fn(&accumulator, &app.wallet)?;
                     let txid = tx.txid();
@@ -211,43 +137,40 @@ impl Melting {
 }
 
 enum MeltInner {
-    SelectUtxos(MeltSelectUtxos),
+    MeltInput(MeltInput),
     Melting(Melting),
 }
 
-impl MeltInner {
-    fn new(app: Option<&App>) -> Self {
-        Self::SelectUtxos(MeltSelectUtxos::new(app))
+impl Default for MeltInner {
+    fn default() -> Self {
+        Self::MeltInput(MeltInput::default())
     }
+}
 
+impl MeltInner {
     fn show(&mut self, app: Option<&App>, ui: &mut egui::Ui) {
         match self {
-            Self::SelectUtxos(select_utxos) => {
-                if let Some(()) = select_utxos.show(ui).inner {
-                    let selected_utxos =
-                        select_utxos.selected_utxos.drain().collect();
-                    let melt_batch = MeltBatch::new(selected_utxos);
+            Self::MeltInput(melt_input) => {
+                if let Some(amount) = melt_input.show(app, ui).inner {
+                    let melt_batch = MeltBatch::new(amount);
                     let melting = Melting::new(app.unwrap(), melt_batch);
                     *self = Self::Melting(melting);
                 }
             }
             Self::Melting(melting) => {
                 if let Some(true) = melting.show(ui) {
-                    *self = Self::SelectUtxos(MeltSelectUtxos::new(app))
+                    *self = Self::MeltInput(MeltInput::default())
                 }
             }
         }
     }
 }
 
+#[derive(Default)]
 #[repr(transparent)]
 pub struct Melt(MeltInner);
 
 impl Melt {
-    pub fn new(app: Option<&App>) -> Self {
-        Self(MeltInner::new(app))
-    }
-
     pub fn show(&mut self, app: Option<&App>, ui: &mut egui::Ui) {
         self.0.show(app, ui);
     }

--- a/app/gui/coins/mod.rs
+++ b/app/gui/coins/mod.rs
@@ -44,7 +44,7 @@ impl Coins {
     pub fn new(app: Option<&App>) -> Self {
         Self {
             cast: Cast::default(),
-            melt: Melt::new(app),
+            melt: Melt::default(),
             shield_unshield: ShieldUnshield::default(),
             transfer_receive: TransferReceive::new(app),
             tab: Tab::default(),

--- a/lib/wallet.rs
+++ b/lib/wallet.rs
@@ -19,7 +19,7 @@ use heed::{
     types::{Bytes, SerdeBincode, U8, U32},
 };
 use parking_lot::RwLock;
-use rand::{Rng, distributions::uniform::UniformSampler};
+use rand::Rng;
 use rayon::prelude::ParallelSliceMut;
 use rustreexo::accumulator::node_hash::BitcoinNodeHash;
 use serde::{Deserialize, Serialize};
@@ -1674,6 +1674,66 @@ impl Watchable<()> for Wallet {
 /// shared constant carries no per-user entropy.
 pub const STANDARD_FEE: Amount = Amount::from_sat(1000);
 
+/// Convert a bill exponent (n in 2^n sats) to the weekday on which a 2^n sats
+/// bill should be melted or cast. Bills of the same denomination share a
+/// weekday across all users, forming an anonymity set.
+fn bill_exponent_to_weekday(exp: u32) -> chrono::Weekday {
+    match exp % 7 {
+        0 => chrono::Weekday::Sat,
+        1 => chrono::Weekday::Fri,
+        2 => chrono::Weekday::Thu,
+        3 => chrono::Weekday::Wed,
+        4 => chrono::Weekday::Tue,
+        5 => chrono::Weekday::Mon,
+        6 => chrono::Weekday::Sun,
+        _ => unreachable!(),
+    }
+}
+
+/// Decompose `amount` into power-of-two bill denominations (one per set bit)
+/// and assign each a timestamp on the weekday for its denomination at a
+/// randomized time of day. Returned sorted by timestamp, low to high.
+fn schedule_bills(amount: Amount) -> VecDeque<(u32, DateTime<Utc>)> {
+    let now = Utc::now();
+    let mut bill_exponents_with_timestamps: Vec<_> = std::iter::from_fn({
+        let mut amount_remaining = amount.to_sat();
+        move || {
+            if amount_remaining == 0 {
+                None
+            } else {
+                let bill_exponent = amount_remaining.ilog2();
+                amount_remaining -= 1 << bill_exponent;
+                let on_weekday = bill_exponent_to_weekday(bill_exponent);
+                let on_date = {
+                    let days_from_now = on_weekday.days_since(now.weekday());
+                    now.date_naive() + chrono::Days::new(days_from_now as u64)
+                };
+                let time_of_day = if now.weekday() == on_weekday {
+                    let min_secs = now.num_seconds_from_midnight();
+                    chrono::NaiveTime::from_num_seconds_from_midnight_opt(
+                        rand::rngs::OsRng.gen_range(min_secs..=86_399),
+                        0,
+                    )
+                    .unwrap()
+                } else {
+                    chrono::NaiveTime::from_hms_opt(
+                        rand::rngs::OsRng.gen_range(0..=23),
+                        rand::rngs::OsRng.gen_range(0..=59),
+                        rand::rngs::OsRng.gen_range(0..=59),
+                    )
+                    .unwrap()
+                };
+                let timestamp =
+                    Utc.from_utc_datetime(&on_date.and_time(time_of_day));
+                Some((bill_exponent, timestamp))
+            }
+        }
+    })
+    .collect();
+    bill_exponents_with_timestamps.sort_by_key(|(_, ts)| *ts);
+    VecDeque::from(bill_exponents_with_timestamps)
+}
+
 /// Represents an ongoing cast
 #[derive(Debug)]
 pub struct Cast {
@@ -1691,67 +1751,9 @@ impl Cast {
         STANDARD_FEE
     }
 
-    /// Convert an bill exponent (n in 2^n sats) to the weekday on which a
-    /// 2^n sats bill should be withdrawn
-    fn bill_exponent_to_weekday(exp: u32) -> chrono::Weekday {
-        match exp % 7 {
-            0 => chrono::Weekday::Sat,
-            1 => chrono::Weekday::Fri,
-            2 => chrono::Weekday::Thu,
-            3 => chrono::Weekday::Wed,
-            4 => chrono::Weekday::Tue,
-            5 => chrono::Weekday::Mon,
-            6 => chrono::Weekday::Sun,
-            _ => unreachable!(),
-        }
-    }
-
     pub fn new(amount: Amount) -> Self {
-        let now = Utc::now();
-        let mut bill_exponents_with_timestamps: Vec<_> = std::iter::from_fn({
-            let mut amount_remaining = amount.to_sat();
-            move || {
-                if amount_remaining == 0 {
-                    None
-                } else {
-                    let bill_exponent = amount_remaining.ilog2();
-                    amount_remaining -= 1 << bill_exponent;
-                    let withdraw_on_weekday =
-                        Self::bill_exponent_to_weekday(bill_exponent);
-                    let withdraw_on_date = {
-                        let days_from_now =
-                            withdraw_on_weekday.days_since(now.weekday());
-                        now.date_naive()
-                            + chrono::Days::new(days_from_now as u64)
-                    };
-                    let time_of_day = if now.weekday() == withdraw_on_weekday {
-                        let min_secs = now.num_seconds_from_midnight();
-                        chrono::NaiveTime::from_num_seconds_from_midnight_opt(
-                            rand::rngs::OsRng.gen_range(min_secs..=86_399),
-                            0,
-                        )
-                        .unwrap()
-                    } else {
-                        chrono::NaiveTime::from_hms_opt(
-                            rand::rngs::OsRng.gen_range(0..=23),
-                            rand::rngs::OsRng.gen_range(0..=59),
-                            rand::rngs::OsRng.gen_range(0..=59),
-                        )
-                        .unwrap()
-                    };
-                    let timestamp = Utc.from_utc_datetime(
-                        &withdraw_on_date.and_time(time_of_day),
-                    );
-                    Some((bill_exponent, timestamp))
-                }
-            }
-        })
-        .collect();
-        bill_exponents_with_timestamps.sort_by_key(|(_, ts)| *ts);
         Self {
-            bill_exponents_with_timestamps: VecDeque::from(
-                bill_exponents_with_timestamps,
-            ),
+            bill_exponents_with_timestamps: schedule_bills(amount),
         }
     }
 
@@ -1776,77 +1778,56 @@ impl Cast {
     }
 }
 
-/// Represents a batch of UTXOs to be melted.
+/// Represents an ongoing melt.
+///
+/// The amount to melt is decomposed into power-of-two "bill" denominations,
+/// each shielded by its own transaction so that the publicly visible value
+/// balance of every melt transaction is a standard denomination rather than the
+/// exact source UTXO value. Bills are spread over time and share denomination
+/// anonymity sets with casts. Each transaction selects confirmed transparent
+/// coins for one bill; any change re-enters the wallet and funds later bills
+/// once it confirms, which the time spread between bills allows for.
 #[derive(Debug)]
 #[must_use]
 pub struct MeltBatch {
-    /// Total time spent waiting for txs to be ready to send
-    elapsed: std::time::Duration,
-    /// UTXOs with total duration from start.
-    utxos_with_duration: VecDeque<((OutPoint, Output), std::time::Duration)>,
+    /// Bill amounts in exponent form (n in 2^n sats) with a timestamp
+    /// indicating the time at which a tx should be created.
+    /// Sorted by timestamp, low to high
+    bill_exponents_with_timestamps: VecDeque<(u32, DateTime<Utc>)>,
 }
 
 impl MeltBatch {
-    pub fn new(utxos: Vec<(OutPoint, Output)>) -> Self {
-        use std::time::Duration;
-        let mut utxos_with_duration: Vec<_> =
-            utxos.into_iter().map(|utxo| {
-                use rand::distributions::uniform;
-                let distribution =  <uniform::UniformDuration as uniform::UniformSampler>::new_inclusive(
-                    Duration::ZERO,
-                    Duration::from_secs(24 * 60 * 60),
-                );
-                let mut duration = distribution.sample(&mut rand::rngs::OsRng);
-                while duration == Duration::ZERO {
-                    // Re-sample if duration is zero
-                    duration = distribution.sample(&mut rand::rngs::OsRng);
-                };
-                (utxo, duration)
-            }).collect();
-        // Sort UTXOs by duration
-        utxos_with_duration.sort_by_key(|(_, duration)| *duration);
+    /// Fee charged for every melt transaction. Shared by all users and
+    /// independent of the bill or the amount, so it cannot be used to link a
+    /// melt's transactions. See [`STANDARD_FEE`].
+    pub fn tx_fee() -> Amount {
+        STANDARD_FEE
+    }
+
+    pub fn new(amount: Amount) -> Self {
         Self {
-            elapsed: Duration::ZERO,
-            utxos_with_duration: VecDeque::from(utxos_with_duration),
+            bill_exponents_with_timestamps: schedule_bills(amount),
         }
     }
 
     pub async fn next_tx(
         &mut self,
-    ) -> Result<
-        Option<
-            impl FnOnce(&Accumulator, &Wallet) -> Result<Transaction, Error>,
-        >,
-        Error,
-    > {
-        // Shared standard fee, not user-chosen, so melt txs cannot be linked
-        // by a per-user fee fingerprint. See [`STANDARD_FEE`].
-        let fee = STANDARD_FEE;
-        let Some(((_, output), duration)) = self.utxos_with_duration.front()
-        else {
-            return Ok(None);
-        };
-        let shield_amount = output
-            .get_value()
-            .checked_sub(fee)
-            .ok_or(Error::NotEnoughFunds)?;
-        if self.elapsed < *duration {
-            let sleep_duration = *duration - self.elapsed;
-            tokio::time::sleep(sleep_duration).await;
-            self.elapsed = *duration;
-        }
-        let (utxo, _) = self.utxos_with_duration.pop_front().unwrap();
+    ) -> Option<impl FnOnce(&Accumulator, &Wallet) -> Result<Transaction, Error>>
+    {
+        let (bill_exponent, ts) =
+            self.bill_exponents_with_timestamps.front()?;
+        let sleep_duration =
+            std::cmp::max(*ts - Utc::now(), chrono::TimeDelta::zero())
+                .to_std()
+                .unwrap();
+        tokio::time::sleep(sleep_duration).await;
+        let amount = Amount::from_sat(1 << bill_exponent);
+        let fee = Self::tx_fee();
+        let _ = self.bill_exponents_with_timestamps.pop_front().unwrap();
         let res = move |accumulator: &Accumulator, wallet: &Wallet| {
-            let rwtxn = wallet.env.write_txn()?;
-            wallet.create_shield_transaction_from_utxos(
-                rwtxn,
-                accumulator,
-                shield_amount,
-                fee,
-                vec![utxo],
-            )
+            wallet.create_shield_transaction(accumulator, amount, fee)
         };
-        Ok(Some(res))
+        Some(res)
     }
 }
 

--- a/lib/wallet.rs
+++ b/lib/wallet.rs
@@ -1894,3 +1894,43 @@ mod fee_privacy_tests {
         }
     }
 }
+
+#[cfg(test)]
+mod melt_privacy_tests {
+    use super::*;
+
+    fn bill_exponents(melt: &MeltBatch) -> Vec<u32> {
+        melt.bill_exponents_with_timestamps
+            .iter()
+            .map(|(exp, _ts)| *exp)
+            .collect()
+    }
+
+    /// A melt decomposes the amount into power-of-two "bill" denominations
+    /// (one shield transaction per set bit). Each transaction therefore shields
+    /// a standard denomination `2^n`, so its publicly visible value balance no
+    /// longer reveals the exact value of a source UTXO.
+    #[test]
+    fn melt_decomposes_into_standard_denominations() {
+        for sats in [1u64, 0b1011, 1_000_000, (1 << 20) + (1 << 5) + 1] {
+            let melt = MeltBatch::new(Amount::from_sat(sats));
+            let mut exps = bill_exponents(&melt);
+            exps.sort_unstable();
+            let expected: Vec<u32> =
+                (0..u64::BITS).filter(|i| (sats >> i) & 1 == 1).collect();
+            assert_eq!(
+                exps, expected,
+                "melt bills must be the set bits of {sats}"
+            );
+            let sum: u64 = exps.iter().map(|exp| 1u64 << exp).sum();
+            assert_eq!(sum, sats, "melt bills must sum back to the amount");
+        }
+    }
+
+    /// Every melt transaction uses the shared standard fee, independent of the
+    /// amount, so melt transactions cannot be linked by a per-user fee.
+    #[test]
+    fn melt_uses_shared_standard_fee() {
+        assert_eq!(MeltBatch::tx_fee(), STANDARD_FEE);
+    }
+}


### PR DESCRIPTION
Built on top of https://github.com/iwakura-rein/thunder-orchard/pull/12

Melt shielded each transparent UTXO as exactly `value - fee` in one transaction. A shield tx's value balance is public, so it revealed `value - fee`, linking the shield to its source UTXO by amount.

## Fix

Melt is now amount-based and denominated, mirroring cast: the amount is split into power-of-two bills, one shield tx per bill spread over time. Each tx shields a standard `2^n`, so its value balance is a standard denomination instead of the exact source amount. Cast and melt now share the bill-scheduling/weekday logic.

## Test

Asserts melt decomposes into power-of-two denominations summing to the amount and uses the shared standard fee.