### PR TITLE
Fix anchor checkpoint depth

### DIFF
--- a/integration_tests/transfers.rs
+++ b/integration_tests/transfers.rs
@@ -128,6 +128,13 @@ const SHIELDED_TRANSFER_FEE: Amount =
 const UNSHIELD_AMOUNT: Amount =
     Amount::from_sat(SHIELDED_TRANSFER_AMOUNT_SATS / 2);
 
+/// Number of blocks to mine so a freshly received shielded note becomes
+/// spendable. Shielded spends anchor a few checkpoints behind the tip (a wallet
+/// privacy/reorg policy), and a note is not witnessable — hence not spendable —
+/// until it is at least that many checkpoints deep. Must be kept `>=` the
+/// wallet's `ANCHOR_CHECKPOINT_DEPTH`.
+const NOTE_MATURITY_BLOCKS: u32 = 3;
+
 async fn transfers_task(
     bin_paths: BinPaths,
     res_tx: mpsc::UnboundedSender<anyhow::Result<()>>,
@@ -227,6 +234,14 @@ async fn transfers_task(
                 == TRANSPARENT_TRANSFER_AMOUNT - SHIELD_AMOUNT
         );
     }
+    // Bob's note is at the tip; shielded spends anchor a few checkpoints behind
+    // the tip, so mine until the note is deep enough to be witnessable/spendable.
+    sidechain_nodes
+        .alice
+        .bmm(&mut enforcer_post_setup, NOTE_MATURITY_BLOCKS)
+        .await?;
+    // Wait for bob to sync the matured note-commitment tree
+    sleep(std::time::Duration::from_secs(5)).await;
     tracing::info!("Shielded transfer (bob -> alice)");
     let _txid = sidechain_nodes
         .bob
@@ -277,6 +292,14 @@ async fn transfers_task(
                     - (SHIELDED_TRANSFER_AMOUNT + SHIELDED_TRANSFER_FEE),
         );
     }
+    // Alice's received note is at the tip; mine until it is deep enough to be
+    // witnessable/spendable (see `NOTE_MATURITY_BLOCKS`).
+    sidechain_nodes
+        .alice
+        .bmm(&mut enforcer_post_setup, NOTE_MATURITY_BLOCKS)
+        .await?;
+    // Wait for alice's wallet to sync the matured note-commitment tree
+    sleep(std::time::Duration::from_secs(5)).await;
     tracing::info!("Unshield (alice -> alice)");
     let _txid = sidechain_nodes
         .alice

--- a/lib/wallet.rs
+++ b/lib/wallet.rs
@@ -2006,3 +2006,58 @@ mod melt_privacy_tests {
         assert_eq!(MeltBatch::tx_fee(), STANDARD_FEE);
     }
 }
+
+#[cfg(test)]
+mod anchor_depth_tests {
+    use super::*;
+    use std::convert::Infallible;
+
+    /// Pick the anchor depth for a tree with `checkpoints` checkpoints: a
+    /// checkpoint exists at depth `d` iff `d < checkpoints`.
+    fn pick(checkpoints: usize, max_depth: usize) -> Option<usize> {
+        deepest_available_anchor_depth(max_depth, |depth| {
+            Ok::<bool, Infallible>(depth < checkpoints)
+        })
+        .unwrap()
+    }
+
+    /// With enough history, spends anchor at the full target depth, i.e. behind
+    /// the tip (depth 0), not at it.
+    #[test]
+    fn anchors_behind_the_tip_when_history_is_deep() {
+        const { assert!(ANCHOR_CHECKPOINT_DEPTH > 0, "must not anchor at the tip") };
+        assert_eq!(
+            pick(100, ANCHOR_CHECKPOINT_DEPTH),
+            Some(ANCHOR_CHECKPOINT_DEPTH)
+        );
+        assert_eq!(pick(10, 3), Some(3));
+    }
+
+    /// While the tree is young, fall back to the deepest available checkpoint.
+    #[test]
+    fn falls_back_to_deepest_available_when_young() {
+        assert_eq!(pick(1, 3), Some(0)); // only the tip checkpoint exists
+        assert_eq!(pick(2, 3), Some(1));
+        assert_eq!(pick(3, 3), Some(2));
+        assert_eq!(pick(4, 3), Some(3));
+    }
+
+    /// No checkpoints (empty tree) yields no anchor depth.
+    #[test]
+    fn no_checkpoints_yields_none() {
+        assert_eq!(pick(0, 3), None);
+        assert_eq!(pick(0, 0), None);
+    }
+
+    /// Privacy property: whenever more than one checkpoint exists, the chosen
+    /// anchor is strictly behind the tip.
+    #[test]
+    fn never_anchors_at_tip_when_history_exists() {
+        for checkpoints in 2..=20 {
+            let depth = pick(checkpoints, ANCHOR_CHECKPOINT_DEPTH).unwrap();
+            assert!(depth >= 1, "anchor must be behind the tip");
+            assert!(depth <= ANCHOR_CHECKPOINT_DEPTH);
+            assert!(depth < checkpoints);
+        }
+    }
+}

--- a/lib/wallet.rs
+++ b/lib/wallet.rs
@@ -181,6 +181,34 @@ impl From<orchard::shardtree_db::db_txn::CommitError> for Error {
     }
 }
 
+/// Number of checkpoints behind the tip to anchor shielded spends against,
+/// rather than the tip itself. A non-tip anchor avoids pinning a spend to the
+/// latest block (a timing correlator) and is reorg-safe. Notes newer than this
+/// many checkpoints are not yet spendable, so this trades spend latency for
+/// timing privacy; it is a tunable policy, not a consensus rule. When the tree
+/// has fewer checkpoints, the deepest available one is used.
+const ANCHOR_CHECKPOINT_DEPTH: usize = 3;
+
+/// Returns the deepest checkpoint depth in `0..=max_depth` for which a
+/// checkpoint exists, or `None` if the tree has no checkpoints. This anchors
+/// shielded spends `max_depth` checkpoints behind the tip, falling back to a
+/// shallower checkpoint while the tree is still young.
+fn deepest_available_anchor_depth<E>(
+    max_depth: usize,
+    mut has_checkpoint_at_depth: impl FnMut(usize) -> Result<bool, E>,
+) -> Result<Option<usize>, E> {
+    let mut depth = max_depth;
+    loop {
+        if has_checkpoint_at_depth(depth)? {
+            return Ok(Some(depth));
+        }
+        if depth == 0 {
+            return Ok(None);
+        }
+        depth -= 1;
+    }
+}
+
 /// Marker type for Wallet Env
 pub struct WalletEnv;
 
@@ -572,13 +600,29 @@ impl Wallet {
             &mut rand::rngs::OsRng,
         );
         let (commitments_tree, _db_txn, txn) = self.get_shard_tree(txn)?;
-        let anchor = match commitments_tree.root_at_checkpoint_depth(Some(0))? {
-            Some(anchor) => anchor.into(),
+        // Spend against an anchor a few checkpoints behind the tip rather than
+        // the tip itself, so the anchor does not pin the spend to the latest
+        // block. Use the deepest available checkpoint up to
+        // `ANCHOR_CHECKPOINT_DEPTH`.
+        let anchor_depth =
+            deepest_available_anchor_depth(ANCHOR_CHECKPOINT_DEPTH, |depth| {
+                Ok::<_, Error>(
+                    commitments_tree
+                        .root_at_checkpoint_depth(Some(depth))?
+                        .is_some(),
+                )
+            })?;
+        let anchor = match anchor_depth {
+            Some(depth) => commitments_tree
+                .root_at_checkpoint_depth(Some(depth))?
+                .expect("checkpoint exists at chosen depth")
+                .into(),
             None => {
                 assert!(nullifiers.is_empty());
                 orchard::Anchor::empty_tree()
             }
         };
+        let anchor_depth = anchor_depth.unwrap_or(0);
         let mut selected = BTreeMap::new();
         let mut total = bitcoin::Amount::ZERO;
         for nullifier in nullifiers {
@@ -587,10 +631,14 @@ impl Wallet {
             }
             let (note, position) =
                 self.orchard_notes.get(txn.as_ref(), &nullifier)?;
-            let path = commitments_tree
-                .witness_at_checkpoint_depth(position.0, 0)?
-                .expect("Should be able to compute merkle path at depth 0")
-                .into();
+            // Skip notes that are newer than the anchor checkpoint: they are
+            // not witnessable against the chosen anchor yet.
+            let Some(path) = commitments_tree
+                .witness_at_checkpoint_depth(position.0, anchor_depth)?
+            else {
+                continue;
+            };
+            let path = path.into();
             total =
                 total.checked_add(note.value()).ok_or(AmountOverflowError)?;
             selected.insert(nullifier, (note, path));
@@ -857,29 +905,53 @@ impl Wallet {
                 nullifiers.as_slice(),
                 &mut rand::rngs::OsRng,
             );
-            let mut builder = if let Some(nullifier) = nullifier {
+            // Spend the consolidation note against an anchor a few checkpoints
+            // behind the tip (see `ANCHOR_CHECKPOINT_DEPTH`), using the deepest
+            // available checkpoint. If the chosen note is newer than that
+            // checkpoint, shield without consolidating rather than pinning to
+            // the tip.
+            let consolidation = if let Some(nullifier) = nullifier {
                 let (spend_note, position) =
                     self.orchard_notes.get(rwtxn.as_ref(), nullifier)?;
-                let flags = orchard::BundleFlags::ENABLED;
                 let (shard_tree, _db_txn, rwtxn_) =
                     self.get_shard_tree(rwtxn)?;
                 rwtxn = rwtxn_;
-                let anchor = shard_tree
-                    .root_at_checkpoint_depth(Some(0))?
-                    .expect("Anchor should exist if notes exist")
-                    .into();
-                let merkle_path = shard_tree
-                    .witness_at_checkpoint_depth(position.0, 0)?
-                    .expect("Merkle path should exist for wallet notes")
-                    .into();
-                let mut builder = orchard::Builder::new(flags, false, anchor);
-                builder.add_spend(fvk, spend_note, merkle_path)?;
-                builder
+                let anchor_depth = deepest_available_anchor_depth(
+                    ANCHOR_CHECKPOINT_DEPTH,
+                    |depth| {
+                        Ok::<_, Error>(
+                            shard_tree
+                                .root_at_checkpoint_depth(Some(depth))?
+                                .is_some(),
+                        )
+                    },
+                )?;
+                match anchor_depth {
+                    Some(depth) => {
+                        let root = shard_tree
+                            .root_at_checkpoint_depth(Some(depth))?
+                            .expect("checkpoint exists at chosen depth");
+                        shard_tree
+                            .witness_at_checkpoint_depth(position.0, depth)?
+                            .map(|path| (root, spend_note, path))
+                    }
+                    None => None,
+                }
             } else {
-                let flags = orchard::BundleFlags::SPENDS_DISABLED;
-                let anchor = orchard::Anchor::empty_tree();
-                orchard::Builder::new(flags, true, anchor)
+                None
             };
+            let mut builder =
+                if let Some((root, spend_note, merkle_path)) = consolidation {
+                    let flags = orchard::BundleFlags::ENABLED;
+                    let mut builder =
+                        orchard::Builder::new(flags, false, root.into());
+                    builder.add_spend(fvk, spend_note, merkle_path.into())?;
+                    builder
+                } else {
+                    let flags = orchard::BundleFlags::SPENDS_DISABLED;
+                    let anchor = orchard::Anchor::empty_tree();
+                    orchard::Builder::new(flags, true, anchor)
+                };
             let output_note_value =
                 shield_amount + builder.value_balance()?.to_unsigned().unwrap();
             builder.add_output(


### PR DESCRIPTION
Shielded spends were anchored against the most recent note-commitment tree root (`root_at_checkpoint_depth(Some(0))` in `select_shielded_coins` and the consolidation spend in `create_shield_transaction_from_utxos`). Anchoring at the tip has 2 downsides:

- It pins the spend's creation to the latest block and creates a timing correlator.
- It is fragile across reorgs. Consensus only accepts anchors in `historical_roots`, and a reorg deletes the reorged-away blocks' roots, so a transaction anchored at a tip that gets reorged becomes invalid and must be rebuilt. 

## Fix

Anchor shielded spends against a checkpoint a few blocks behind the tip (`ANCHOR_CHECKPOINT_DEPTH = 3`) instead of the tip itself, falling back to the deepest available checkpoint while the tree is still young. Notes newer than the anchor are skipped (not yet witnessable); the consolidation spend falls back to no consolidation if its note is too new. The depth-selection is factored into asmall `deepest_available_anchor_depth` helper shared by both anchor sites.

`ANCHOR_CHECKPOINT_DEPTH` is a tunable wallet policy, not a consensus rule. It trades a small spend-maturity delay (a note must be this many checkpoints deep to be spent) for timing privacy and reorg safety; reviewers may want to tune it to the chain's block time.

## Test

Unit tests for `deepest_available_anchor_depth`: anchors at the full target depth with deep history, falls back to the deepest available when young, returns `None` for an empty tree and the privacy property never anchors at the tip whenever more than one checkpoint exists.