### PR TITLE
fix: upgrade orchard to 0.14.0 and halo2_gadgets to 0.5.0 for Orchard circuit soundness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2907,9 +2907,9 @@ dependencies = [
 
 [[package]]
 name = "halo2_gadgets"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45824ce0dd12e91ec0c68ebae2a7ed8ae19b70946624c849add59f1d1a62a143"
+checksum = "fb2a697cad929f706b7987fe804ad57d43622cd37463ba7e4d662a926fdcfea3"
 dependencies = [
  "arrayvec",
  "bitvec",
@@ -5044,9 +5044,9 @@ dependencies = [
 
 [[package]]
 name = "orchard"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497e74492624a1d1cc8c9675a7afb17b430d32fd9efc171513d0840140b5f0c7"
+checksum = "a54f8d29bfb1e76a9d4e868a1a08cce2e57dd2bdc66232982822ad3114b91ab3"
 dependencies = [
  "aes",
  "bitvec",
@@ -5562,7 +5562,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools 0.14.0",
  "log",
  "multimap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ jsonrpsee = { version = "0.25.1", features = ["tracing"] }
 libtest-mimic = "0.8.1"
 mimalloc = "0.1.48"
 nonempty = "0.11.0"
-orchard = "0.13.0"
+orchard = "0.14.0"
 parking_lot = "0.12.3"
 poll-promise = "0.3.0"
 prost = "0.14.1"

--- a/lib/types/orchard/mod.rs
+++ b/lib/types/orchard/mod.rs
@@ -655,6 +655,113 @@ enum InvalidActionErrorInner {
 #[repr(transparent)]
 pub struct InvalidActionError(#[from] InvalidActionErrorInner);
 
+/// Error constructing an [`orchard::bundle::Bundle`] from deserialized parts.
+///
+/// As of orchard 0.14, building an authorized bundle can fail if its proof is
+/// not the expected size for the number of actions.
+#[derive(Debug, Error)]
+pub enum InvalidBundleError {
+    #[error(transparent)]
+    Action(#[from] InvalidActionError),
+    #[error("invalid orchard bundle: {0}")]
+    Bundle(String),
+}
+
+/// Construct an [`orchard::bundle::Bundle`] from its parts, dispatching to the
+/// orchard constructor appropriate for the authorization type. This replaces
+/// the generic `Bundle::from_parts` that orchard 0.14 removed: authorized
+/// bundles go through the fallible, proof-size-checked `try_from_parts`, while
+/// effects-only bundles use the infallible `from_parts`.
+trait BundleFromParts: BundleAuthorization + Sized {
+    fn bundle_from_parts(
+        actions: NonEmpty<orchard::Action<Self::SpendAuth>>,
+        flags: orchard::bundle::Flags,
+        value_balance: i64,
+        anchor: orchard::tree::Anchor,
+        authorization: Self,
+    ) -> Result<orchard::bundle::Bundle<Self, i64>, InvalidBundleError>;
+}
+
+impl BundleFromParts for Authorized {
+    fn bundle_from_parts(
+        actions: NonEmpty<orchard::Action<Self::SpendAuth>>,
+        flags: orchard::bundle::Flags,
+        value_balance: i64,
+        anchor: orchard::tree::Anchor,
+        authorization: Self,
+    ) -> Result<orchard::bundle::Bundle<Self, i64>, InvalidBundleError> {
+        // orchard's `try_from_parts` is defined only for the native
+        // `orchard::bundle::Authorized`, so rebuild each action with the native
+        // redpallas spend-auth signature type, construct the native bundle, then
+        // map the authorization back to the wrapper types used in this crate.
+        fn native_action(
+            action: orchard::Action<Signature<SpendAuth>>,
+        ) -> Result<
+            orchard::Action<redpallas::Signature<SpendAuth>>,
+            InvalidActionError,
+        > {
+            orchard::Action::from_parts(
+                *action.nullifier(),
+                action.rk().clone(),
+                *action.cmx(),
+                action.encrypted_note().clone(),
+                action.cv_net().clone(),
+                Signature::peel(action.authorization().clone()),
+            )
+            .map_err(|_| {
+                InvalidActionError(InvalidActionErrorInner::RkIdentityPoint)
+            })
+        }
+        let NonEmpty { head, tail } = actions;
+        let head = native_action(head)?;
+        let tail = tail
+            .into_iter()
+            .map(native_action)
+            .collect::<Result<Vec<_>, _>>()?;
+        let native_actions = NonEmpty { head, tail };
+        let native = orchard::bundle::Bundle::<
+            orchard::bundle::Authorized,
+            i64,
+        >::try_from_parts(
+            native_actions,
+            flags,
+            value_balance,
+            anchor,
+            authorization.0,
+            orchard::bundle::ProofSizeEnforcement::Strict,
+        )
+        .map_err(|err| InvalidBundleError::Bundle(err.to_string()))?;
+        let bundle = native.map_authorization(
+            &mut (),
+            |_: &mut (),
+             _: &orchard::bundle::Authorized,
+             spend_auth: redpallas::Signature<SpendAuth>| {
+                Signature::<SpendAuth>::wrap(spend_auth)
+            },
+            |_: &mut (), auth: orchard::bundle::Authorized| Authorized(auth),
+        );
+        Ok(bundle)
+    }
+}
+
+impl BundleFromParts for EffectsOnly {
+    fn bundle_from_parts(
+        actions: NonEmpty<orchard::Action<Self::SpendAuth>>,
+        flags: orchard::bundle::Flags,
+        value_balance: i64,
+        anchor: orchard::tree::Anchor,
+        authorization: Self,
+    ) -> Result<orchard::bundle::Bundle<Self, i64>, InvalidBundleError> {
+        Ok(orchard::bundle::Bundle::from_parts(
+            actions,
+            flags,
+            value_balance,
+            anchor,
+            authorization,
+        ))
+    }
+}
+
 /// Borsh/Serde representation for [`Action`]
 #[serde_as]
 #[derive(Deserialize, Educe, Serialize)]
@@ -745,7 +852,9 @@ impl<Auth> TryFrom<ActionRepr<'_, Auth, Owned>> for orchard::Action<Auth> {
             ValueCommitment::from(repr.cv_net).0,
             repr.authorization,
         )
-        .ok_or(InvalidActionError(InvalidActionErrorInner::RkIdentityPoint))
+        .map_err(|_| {
+            InvalidActionError(InvalidActionErrorInner::RkIdentityPoint)
+        })
     }
 }
 
@@ -766,19 +875,18 @@ impl<Auth> Action<Auth> {
         cv_net: ValueCommitment,
         authorization: Auth,
     ) -> Result<Self, InvalidActionError> {
-        match orchard::Action::from_parts(
+        orchard::Action::from_parts(
             nf.0,
             rk.0,
             cmx.0,
             encrypted_note.0,
             cv_net.0,
             authorization,
-        ) {
-            Some(action) => Ok(Self(action)),
-            None => Err(InvalidActionError(
-                InvalidActionErrorInner::RkIdentityPoint,
-            )),
-        }
+        )
+        .map(Self)
+        .map_err(|_| {
+            InvalidActionError(InvalidActionErrorInner::RkIdentityPoint)
+        })
     }
 
     pub fn cmx(&self) -> &ExtractedNoteCommitment {
@@ -1478,13 +1586,17 @@ where
     }
 }
 
-impl<Auth> From<BundleRepr<'_, Auth, Owned>>
+impl<Auth> TryFrom<BundleRepr<'_, Auth, Owned>>
     for orchard::bundle::Bundle<Auth, i64>
 where
-    Auth: BundleAuthorization,
+    Auth: BundleFromParts,
 {
-    fn from(repr: BundleRepr<'_, Auth, Owned>) -> Self {
-        Self::from_parts(
+    type Error = InvalidBundleError;
+
+    fn try_from(
+        repr: BundleRepr<'_, Auth, Owned>,
+    ) -> Result<Self, Self::Error> {
+        Auth::bundle_from_parts(
             peel_nonempty(repr.actions),
             repr.flags.0,
             repr.balance.to_sat(),
@@ -1498,8 +1610,8 @@ where
 #[educe(Clone(bound(Auth: Clone, Auth::SpendAuth: Clone)))]
 #[repr(transparent)]
 #[serde(
-    bound = "Auth: 'de, BundleRepr<'de, Auth, Owned>: Deserialize<'de>",
-    from = "BundleRepr<Auth, Owned>"
+    bound = "Auth: BundleFromParts + 'de, BundleRepr<'de, Auth, Owned>: Deserialize<'de>",
+    try_from = "BundleRepr<Auth, Owned>"
 )]
 pub struct Bundle<Auth>(orchard::bundle::Bundle<Auth, i64>)
 where
@@ -1509,22 +1621,6 @@ impl<Auth> Bundle<Auth>
 where
     Auth: BundleAuthorization,
 {
-    pub fn new(
-        actions: NonEmpty<Action<Auth::SpendAuth>>,
-        flags: BundleFlags,
-        value_balance: bitcoin::SignedAmount,
-        anchor: Anchor,
-        authorization: Auth,
-    ) -> Self {
-        Self(orchard::Bundle::from_parts(
-            peel_nonempty(actions),
-            flags.0,
-            value_balance.to_sat(),
-            anchor.0,
-            authorization,
-        ))
-    }
-
     fn peel_ref<Inner>(&self) -> &Bundle<Inner>
     where
         Auth: TransparentWrapper<Inner>,
@@ -1697,12 +1793,16 @@ where
     }
 }
 
-impl<Auth> From<BundleRepr<'_, Auth, Owned>> for Bundle<Auth>
+impl<Auth> TryFrom<BundleRepr<'_, Auth, Owned>> for Bundle<Auth>
 where
-    Auth: BundleAuthorization,
+    Auth: BundleFromParts,
 {
-    fn from(repr: BundleRepr<'_, Auth, Owned>) -> Self {
-        Self(repr.into())
+    type Error = InvalidBundleError;
+
+    fn try_from(
+        repr: BundleRepr<'_, Auth, Owned>,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self(repr.try_into()?))
     }
 }
 


### PR DESCRIPTION
## Problem

The Orchard circuit soundness vulnerability disclosed for Zcash (fixed in `halo2_gadgets` 0.5.0 / `orchard` 0.14.0 on 2026-06-03) is inherited here through the pinned dependencies. The tree pins:

- `orchard = 0.13.1` — **yanked** on 2026-06-03
- `halo2_gadgets = 0.4.0` — superseded by the 0.5.0 security release

Proof verification (`Bundle::verify_proof`) uses the upstream verifying key, so the vulnerable circuit is inherited one-for-one. Unlike Zcash there is no turnstile here to bound the impact, so a circuit-soundness break combined with the per-tx `value_balance` accounting is an unshield-from-nothing / peg-drain risk.

## Fix

Bump `orchard` to `0.14.0` (which pulls `halo2_gadgets` `0.5.0` transitively) and regenerate `Cargo.lock`.

orchard 0.14 is not a drop-in; it has breaking API changes that required migrating the consensus-critical bundle (de)serialization in `lib/types/orchard/mod.rs`:

- `orchard::Action::from_parts` now returns `Result` instead of `Option` (updated both call sites).
- The generic public `Bundle::from_parts` was removed (`from_parts_unchecked` is now `pub(crate)`). Added a `BundleFromParts` trait that constructs:
  - an authorized bundle via the fallible `Bundle::<Authorized>::try_from_parts(..., ProofSizeEnforcement::Strict)`, then `map_authorization`s the native bundle back into this crate's wrapper auth/signature types;
  - an effects-only bundle via the infallible `Bundle::<EffectsOnly>::from_parts`.
- The wrapper `Bundle<Auth>` deserialize path switches from infallible serde `from` to fallible `try_from` (it can now fail during construction).
- Removed the now-unused wrapper `Bundle::new`.

---

`try_from_parts` with `ProofSizeEnforcement::Strict` rejects a proof whose byte length is not the canonical size for the number of actions (a proof-padding DoS hardening added in orchard 0.14). A bundle carrying a non-canonical/padded proof now fails to deserialize. 