### PR TITLE
Reject spending withdrawal outputs in transactions

### DIFF
--- a/lib/state/error.rs
+++ b/lib/state/error.rs
@@ -265,6 +265,8 @@ pub enum Error {
     NotEnoughValueIn,
     #[error(transparent)]
     NoUtxo(#[from] NoUtxo),
+    #[error("withdrawal output cannot be spent by a transaction")]
+    SpendWithdrawalOutput,
     #[error("Withdrawal bundle event block doesn't exist")]
     NoWithdrawalBundleEventBlock,
     #[error("Orchard error")]

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -346,6 +346,10 @@ impl State {
         let mut value_in = bitcoin::Amount::ZERO;
         let mut value_out = bitcoin::Amount::ZERO;
         for utxo in &transaction.spent_utxos {
+            // a withdrawal output is committed to a bundle, not spendable by a tx
+            if utxo.content.is_withdrawal() {
+                return Err(Error::SpendWithdrawalOutput);
+            }
             value_in = value_in
                 .checked_add(utxo.get_value())
                 .ok_or(AmountOverflowError)?;

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -662,8 +662,9 @@ mod test {
     use crate::{
         state::State,
         types::{
-            InPoint, OutPoint, OutPointKey, Output, OutputContent, SpentOutput,
-            TransparentAddress,
+            FilledTransaction, InPoint, OutPoint, OutPointKey, Output,
+            OutputContent, PointedOutputRef, SpentOutput, TransparentAddress,
+            Transaction, hash,
         },
     };
 
@@ -703,6 +704,43 @@ mod test {
             address,
             content: OutputContent::Value(bitcoin::Amount::from_sat(sats)),
         }
+    }
+
+    #[test]
+    fn cannot_spend_withdrawal_output() -> anyhow::Result<()> {
+        let (_env, state) = fresh_state("cannot-spend-withdrawal-output")?;
+        let main_address = "1BvBMSEYstWetqTFn5Au4m4GFg7xJaNVN2"
+            .parse::<bitcoin::Address<bitcoin::address::NetworkUnchecked>>()
+            .unwrap();
+        let withdrawal = Output {
+            address: TransparentAddress::ALL_ZEROS,
+            content: OutputContent::Withdrawal {
+                value: bitcoin::Amount::from_sat(1000),
+                main_fee: bitcoin::Amount::from_sat(300),
+                main_address,
+            },
+        };
+        let outpoint = OutPoint::Regular {
+            txid: [1; 32].into(),
+            vout: 0,
+        };
+        let utxo_hash = hash(&PointedOutputRef {
+            outpoint,
+            output: &withdrawal,
+        });
+        let tx = FilledTransaction {
+            transaction: Transaction {
+                inputs: vec![(outpoint, utxo_hash)],
+                outputs: vec![value_output(TransparentAddress::ALL_ZEROS, 1300)],
+                ..Default::default()
+            },
+            spent_utxos: vec![withdrawal],
+        };
+        assert!(matches!(
+            state.validate_filled_transaction(&tx),
+            Err(crate::state::Error::SpendWithdrawalOutput)
+        ));
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
A withdrawal output (`OutputContent::Withdrawal`) is created with the withdrawing user's own transparent address (`create_withdrawal` - `get_new_transparent_address`) and lives in the UTXO set. `collect_withdrawal_bundle` only **reads** those UTXOs to build the M6 it never removes or locks them; they're removed only later in `connect_withdrawal_bundle_submitted`. During that Pending-Submitted window nothing rejected spending the withdrawal output: `validate_filled_transaction` only checked value conservation, and `is_withdrawal()` was used only in wallet coin-selection.

So the owner can re-spend the in-flight withdrawal output back to a `Value` output on L2 (value in == out, own-key authorized) while the collected M6 pays the same value out on L1 a double-spend / peg insolvency (loss of funds).

## Fix

`validate_filled_transaction` now rejects any transaction that spends a `Withdrawal`-content output (`Error::SpendWithdrawalOutput`). A withdrawal output is committed to a bundle and may only be consumed by the bundle mechanism.
