### PR TITLE
fix: P2P: block merkle roots not validated before inserting into archive DB

### DIFF
--- a/lib/archive.rs
+++ b/lib/archive.rs
@@ -711,6 +711,36 @@ impl Archive {
             })
     }
 
+    /// Delete a stored body, reversing the effects of [`Self::put_body`].
+    ///
+    /// Used to discard a body that was stored before its contents could be
+    /// validated (e.g. a body received from a peer) and later turned out to be
+    /// invalid, so that the block is reported missing again by
+    /// [`Self::iter_missing_bodies`] and the real body is re-requested.
+    pub fn delete_body(
+        &self,
+        rwtxn: &mut RwTxn,
+        block_hash: BlockHash,
+        body: &Body,
+    ) -> Result<(), Error> {
+        self.bodies
+            .delete(rwtxn, &block_hash)
+            .map_err(DbError::from)?;
+        body.transactions.iter().try_for_each(|tx| {
+            let txid = tx.txid();
+            let mut inclusions = self.get_tx_inclusions(rwtxn, txid)?;
+            inclusions.remove(&block_hash);
+            if inclusions.is_empty() {
+                self.txid_to_inclusions
+                    .delete(rwtxn, &txid)
+                    .map_err(DbError::from)?;
+            } else {
+                self.txid_to_inclusions.put(rwtxn, &txid, &inclusions)?;
+            }
+            Ok(())
+        })
+    }
+
     /// Store a header.
     ///
     /// The following predicates MUST be met before calling this function:

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -387,7 +387,7 @@ fn reorg_to_tip(
             }
             two_way_peg_data
         };
-        let () = connect_tip_(
+        if let Err(err) = connect_tip_(
             &mut rwtxn,
             archive,
             mempool,
@@ -395,7 +395,18 @@ fn reorg_to_tip(
             &header,
             &body,
             &two_way_peg_data,
-        )?;
+        ) {
+            // The stored body for this block failed validation (e.g. a peer
+            // supplied a body whose contents do not match the header's merkle
+            // root). Abort the reorg and discard the invalid body from the
+            // archive so that the block is reported missing again and the real
+            // body is re-requested, instead of the archive staying poisoned.
+            drop(rwtxn);
+            let mut rwtxn = env.write_txn().map_err(EnvError::from)?;
+            let () = archive.delete_body(&mut rwtxn, header.hash(), &body)?;
+            rwtxn.commit().map_err(RwTxnError::from)?;
+            return Err(err);
+        }
         let new_tip_hash = state
             .try_get_tip(&rwtxn)
             .map_err(state::Error::from)?
@@ -1007,8 +1018,8 @@ impl NetTask {
                         }
                     }
                 }
-                MailboxItem::NewTipReady(new_tip, _addr, resp_tx) => {
-                    let reorg_applied = task::block_in_place(|| {
+                MailboxItem::NewTipReady(new_tip, addr, resp_tx) => {
+                    let reorg_result = task::block_in_place(|| {
                         reorg_to_tip(
                             &self.ctxt.env,
                             &self.ctxt.archive,
@@ -1016,7 +1027,26 @@ impl NetTask {
                             &self.ctxt.state,
                             new_tip,
                         )
-                    })?;
+                    });
+                    // A tip supplied by a peer may carry a body that fails
+                    // validation. Do not let that error propagate out of `run`
+                    // and halt the whole net task: log it and drop the
+                    // offending peer instead. `reorg_to_tip` has already
+                    // discarded the invalid body so it will be re-requested.
+                    let reorg_applied = match reorg_result {
+                        Ok(reorg_applied) => reorg_applied,
+                        Err(err) => {
+                            tracing::warn!(
+                                ?addr,
+                                %err,
+                                "Failed to reorg to new tip; dropping peer"
+                            );
+                            if let Some(addr) = addr {
+                                let () = self.ctxt.net.remove_active_peer(addr);
+                            }
+                            false
+                        }
+                    };
                     if let Some(resp_tx) = resp_tx {
                         let () = resp_tx
                             .send(reorg_applied)


### PR DESCRIPTION
## Summary

Reconciled the port — resolved the `reorg_to_tip` conflict (abort reorg + `archive.delete_body` on `connect_tip_` failure, using this repo's `state::Error::from` idiom) alongside the cleanly-applied `delete_body` helper and the `NewTipReady` handler that logs+drops the peer instead of halting `NetTask::run`.

## The bug

P2P: block merkle roots not validated before inserting into archive DB

Severity: Medium. Full technical write-up (access-controlled): https://giaki3003.tech/#/findings/20260603-2200-thunder-peer-body-poison-archive-and-net-task-halt

## Notes

First of a short series of fixes for this repo from a security review; the remaining fixes stack on this branch and will follow as separate PRs. Happy to adjust scope or split further on request.