### PR TITLE
fix: Mempool: a peer transaction conflict halts the net task

### DIFF
--- a/app/app.rs
+++ b/app/app.rs
@@ -42,6 +42,8 @@ pub enum Error {
     NoCusfMainchainWalletClient,
     #[error("Failed to request mainchain ancestor info for {block_hash}")]
     RequestMainchainAncestorInfos { block_hash: bitcoin::BlockHash },
+    #[error("Failed to submit transaction")]
+    SubmitTransaction(#[from] node::error::SubmitTransaction),
     #[error("Utreexo error: {0}")]
     Utreexo(String),
     #[error("Unable to verify existence of CUSF mainchain service(s) at {url}")]

--- a/lib/authorization.rs
+++ b/lib/authorization.rs
@@ -1,9 +1,11 @@
 use borsh::BorshSerialize;
+use error_fatality::{Fatality, Split};
 use rayon::{
     iter::{IntoParallelRefIterator as _, ParallelIterator as _},
     slice::ParallelSlice as _,
 };
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 use utoipa::ToSchema;
 
 use crate::types::{
@@ -22,24 +24,32 @@ pub fn get_address(verifying_key: &VerifyingKey) -> TransparentAddress {
     TransparentAddress(output)
 }
 
-#[derive(Debug, thiserror::Error)]
+/// Non-fatal variants indicate tx rejection reason
+#[derive(Debug, Error, Fatality, Split)]
 pub enum Error {
     #[error("borsh serialization error")]
+    #[fatal(true)]
     BorshSerialize(#[from] borsh::io::Error),
     #[error("ed25519_dalek error")]
+    #[fatal(false)]
     DalekError(#[from] SignatureError),
     #[error("not enough authorizations")]
+    #[fatal(false)]
     NotEnoughAuthorizations,
     #[error("too many authorizations")]
+    #[fatal(false)]
     TooManyAuthorizations,
     #[error("Orchard bundle proof verification error")]
+    #[fatal(false)]
     OrchardProof(#[from] orchard::BundleProofVerificationError),
     #[error("Orchard signature verification error")]
+    #[fatal(false)]
     OrchardSignature(#[from] orchard::SignatureVerificationError),
     #[error(
         "wrong key for address: address = {address},
              hash(verifying_key) = {hash_verifying_key}"
     )]
+    #[fatal(false)]
     WrongKeyForAddress {
         address: TransparentAddress,
         hash_verifying_key: TransparentAddress,

--- a/lib/mempool/error.rs
+++ b/lib/mempool/error.rs
@@ -1,0 +1,106 @@
+use sneed::{db::error as db, env::error as env, rwtxn::error as rwtxn};
+use thiserror::Error;
+use transitive::Transitive;
+
+use crate::types::{Txid, UtreexoError};
+
+#[derive(Debug, Error)]
+pub enum TxRejected {
+    #[error("nullifier already used by tx ({conflicts_with})")]
+    NullifierDoubleSpent { conflicts_with: Txid },
+    #[error(
+        "input ({double_spent_vin}) already spent by tx ({conflicts_with})"
+    )]
+    UtxoDoubleSpent {
+        double_spent_vin: usize,
+        conflicts_with: Txid,
+    },
+}
+
+pub mod insert {
+    use error_fatality::{Fatality, Split};
+    use sneed::db::error as db;
+    use thiserror::Error;
+
+    use crate::mempool::error::TxRejected;
+
+    #[derive(Debug, Error)]
+    pub enum Fatal {
+        #[error(transparent)]
+        DbPut(#[from] db::Put),
+        #[error(transparent)]
+        DbTryGet(#[from] db::TryGet),
+    }
+
+    /// Non-fatal variants indicate tx rejection reason
+    #[derive(Debug, Error, Fatality)]
+    pub enum Error {
+        #[error(transparent)]
+        #[fatal(true)]
+        DbPut(#[from] db::Put),
+        #[error(transparent)]
+        #[fatal(true)]
+        DbTryGet(#[from] db::TryGet),
+        #[error(transparent)]
+        #[fatal(false)]
+        TxRejected(#[from] TxRejected),
+    }
+
+    impl Split for Error {
+        type Fatal = Fatal;
+        type Jfyi = TxRejected;
+
+        fn split(self) -> std::result::Result<Self::Jfyi, Self::Fatal> {
+            match self {
+                Self::DbPut(err) => Err(Fatal::DbPut(err)),
+                Self::DbTryGet(err) => Err(Fatal::DbTryGet(err)),
+                Self::TxRejected(jfyi) => Ok(jfyi),
+            }
+        }
+    }
+}
+pub use insert::Error as Insert;
+
+#[allow(clippy::duplicated_attributes)]
+#[derive(Debug, Error, Transitive)]
+#[transitive(
+    from(db::Delete, db::Error),
+    from(db::Get, db::Error),
+    from(db::IterInit, db::Error),
+    from(db::IterItem, db::Error),
+    from(db::Put, db::Error),
+    from(db::TryGet, db::Error),
+    from(env::CreateDb, env::Error),
+    from(env::WriteTxn, env::Error)
+)]
+pub enum Error {
+    #[error(transparent)]
+    Db(#[from] Box<db::Error>),
+    #[error("Database env error")]
+    DbEnv(#[from] Box<env::Error>),
+    #[error("Database write error")]
+    DbWrite(#[from] rwtxn::Error),
+    #[error(transparent)]
+    Utreexo(#[from] UtreexoError),
+}
+
+impl From<db::Error> for Error {
+    fn from(err: db::Error) -> Self {
+        Self::Db(Box::new(err))
+    }
+}
+
+impl From<env::Error> for Error {
+    fn from(err: env::Error) -> Self {
+        Self::DbEnv(Box::new(err))
+    }
+}
+
+impl From<insert::Fatal> for Error {
+    fn from(err: insert::Fatal) -> Self {
+        match err {
+            insert::Fatal::DbPut(err) => err.into(),
+            insert::Fatal::DbTryGet(err) => err.into(),
+        }
+    }
+}

--- a/lib/mempool/mod.rs
+++ b/lib/mempool/mod.rs
@@ -2,62 +2,15 @@ use std::collections::VecDeque;
 
 use fallible_iterator::FallibleIterator as _;
 use heed::types::SerdeBincode;
-use sneed::{DatabaseUnique, RoTxn, RwTxn, RwTxnError, UnitKey, db, env};
-use thiserror::Error;
-use transitive::Transitive;
+use sneed::{DatabaseUnique, RoTxn, RwTxn, RwTxnError, UnitKey};
 
 use crate::types::{
-    Accumulator, AuthorizedTransaction, Body, OutPoint, Txid, UtreexoError,
-    VERSION, Version, orchard::Nullifier,
+    Accumulator, AuthorizedTransaction, Body, OutPoint, Txid, VERSION, Version,
+    orchard::Nullifier,
 };
 
-#[allow(clippy::duplicated_attributes)]
-#[derive(Debug, Error, Transitive)]
-#[transitive(
-    from(db::error::Delete, db::Error),
-    from(db::error::Get, db::Error),
-    from(db::error::IterInit, db::Error),
-    from(db::error::IterItem, db::Error),
-    from(db::error::Put, db::Error),
-    from(db::error::TryGet, db::Error),
-    from(env::error::CreateDb, env::Error),
-    from(env::error::WriteTxn, env::Error)
-)]
-pub enum Error {
-    #[error(transparent)]
-    Db(#[from] Box<db::Error>),
-    #[error("Database env error")]
-    DbEnv(#[from] Box<env::Error>),
-    #[error("Database write error")]
-    DbWrite(#[from] RwTxnError),
-    #[error(
-        "can't add transaction (`{}`), nullifier (`{}`) already used by (`{}`)",
-        .new_txid,
-        .nullifier,
-        .old_txid,
-    )]
-    NullifierDoubleSpent {
-        new_txid: Txid,
-        nullifier: Nullifier,
-        old_txid: Txid,
-    },
-    #[error(transparent)]
-    Utreexo(#[from] UtreexoError),
-    #[error("can't add transaction (`{txid}`), utxo double spent")]
-    UtxoDoubleSpent { txid: Txid },
-}
-
-impl From<db::Error> for Error {
-    fn from(err: db::Error) -> Self {
-        Self::Db(Box::new(err))
-    }
-}
-
-impl From<env::Error> for Error {
-    fn from(err: env::Error) -> Self {
-        Self::DbEnv(Box::new(err))
-    }
-}
+pub mod error;
+pub use error::Error;
 
 #[derive(Clone)]
 pub struct MemPool {
@@ -94,36 +47,40 @@ impl MemPool {
         })
     }
 
-    pub fn put(
+    pub fn insert(
         &self,
         rwtxn: &mut RwTxn,
         transaction: &AuthorizedTransaction,
-    ) -> Result<(), Error> {
+    ) -> Result<(), error::Insert> {
         let txid = transaction.transaction.txid();
         if self.transactions.contains_key(rwtxn, &txid)? {
             tracing::debug!(%txid, "transaction already in mempool");
             return Ok(());
         }
         tracing::debug!("adding transaction {txid} to mempool");
-        for (outpoint, _) in &transaction.transaction.inputs {
-            if self.spent_utxos.try_get(rwtxn, outpoint)?.is_some() {
-                return Err(Error::UtxoDoubleSpent {
-                    txid: transaction.transaction.txid(),
-                });
+        for (vin, (outpoint, _)) in
+            transaction.transaction.inputs.iter().enumerate()
+        {
+            if let Some(conflicts_with) =
+                self.spent_utxos.try_get(rwtxn, outpoint)?
+            {
+                let err = error::TxRejected::UtxoDoubleSpent {
+                    double_spent_vin: vin,
+                    conflicts_with,
+                };
+                return Err(err.into());
             }
             self.spent_utxos.put(rwtxn, outpoint, &txid)?;
         }
         if let Some(orchard_bundle) = &transaction.transaction.orchard_bundle {
             for nullifier in orchard_bundle.nullifiers() {
-                if let Some(old_txid) =
+                if let Some(conflicts_with) =
                     self.used_nullifiers.try_get(rwtxn, nullifier)?
                 {
-                    let err = Error::NullifierDoubleSpent {
-                        new_txid: txid,
-                        nullifier: *nullifier,
-                        old_txid,
+                    let err = error::TxRejected::NullifierDoubleSpent {
+                        conflicts_with,
                     };
-                    return Err(err);
+                    return Err(err.into());
                 }
                 self.used_nullifiers.put(rwtxn, nullifier, &txid)?;
             }

--- a/lib/net/peer/error.rs
+++ b/lib/net/peer/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::net::peer::PeerStateId;
+use crate::{net::peer::PeerStateId, state::error as state, types::Txid};
 
 pub(in crate::net::peer) mod connection {
     use thiserror::Error;
@@ -305,6 +305,11 @@ pub enum Error {
     SendResponse(#[from] connection::SendResponse),
     #[error("state error")]
     State(#[from] Box<crate::state::Error>),
+    #[error("failed to validate tx ({txid})")]
+    ValidateTransaction {
+        source: state::ValidateTransaction,
+        txid: Txid,
+    },
 }
 
 impl From<crate::state::Error> for Error {

--- a/lib/net/peer/task.rs
+++ b/lib/net/peer/task.rs
@@ -660,6 +660,7 @@ impl ConnectionTask {
         response_tx: SendStream,
         tx: Box<AuthorizedTransaction>,
     ) -> Result<(), Error> {
+        use error_fatality::Fatality as _;
         let txid = tx.transaction.txid();
         let validate_tx_result = {
             let rotxn = ctxt.env.read_txn().map_err(EnvError::from)?;
@@ -667,13 +668,15 @@ impl ConnectionTask {
         };
         match validate_tx_result {
             Err(err) => {
-                Connection::send_response(
-                    ctxt.network,
-                    response_tx,
-                    ResponseMessage::TransactionRejected(txid),
-                )
-                .await?;
-                Err(Error::from(err))
+                if !err.is_fatal() {
+                    Connection::send_response(
+                        ctxt.network,
+                        response_tx,
+                        ResponseMessage::TransactionRejected(txid),
+                    )
+                    .await?;
+                }
+                Err(Error::ValidateTransaction { source: err, txid })
             }
             Ok(_) => {
                 Connection::send_response(

--- a/lib/node/error.rs
+++ b/lib/node/error.rs
@@ -1,0 +1,98 @@
+use error_fatality::{Fatality, Split};
+use sneed::{db::error as db, env::error as env, rwtxn::error as rwtxn};
+use thiserror::Error;
+use transitive::Transitive;
+
+use crate::{
+    archive,
+    mempool::error as mempool,
+    net::error as net,
+    node::{mainchain_task, net_task},
+    state::error as state,
+    types::{AmountOverflowError, AmountUnderflowError, proto},
+};
+
+/// Non-fatal variants indicate tx rejection reason
+#[derive(Debug, Error, Fatality, Split)]
+pub enum SubmitTransaction {
+    #[error(transparent)]
+    #[fatal(true)]
+    CommitRwTxn(#[from] rwtxn::Commit),
+    #[error(transparent)]
+    #[fatal(true)]
+    EnvWriteTxn(#[from] env::WriteTxn),
+    #[error("failed to insert tx into mempool")]
+    #[fatal(forward)]
+    MempoolInsert(#[from] mempool::Insert),
+    #[error("failed to validate transaction")]
+    #[fatal(forward)]
+    Validate(#[from] state::ValidateTransaction),
+}
+
+#[allow(clippy::duplicated_attributes)]
+#[derive(Debug, Error, Transitive)]
+#[transitive(
+    from(env::ReadTxn, env::Error),
+    from(env::WriteTxn, env::Error),
+    from(rwtxn::Commit, rwtxn::Error)
+)]
+pub enum Error {
+    #[error("address parse error")]
+    AddrParse(#[from] std::net::AddrParseError),
+    #[error(transparent)]
+    AmountOverflow(#[from] AmountOverflowError),
+    #[error(transparent)]
+    AmountUnderflow(#[from] AmountUnderflowError),
+    #[error("archive error")]
+    Archive(#[from] archive::Error),
+    #[error("CUSF mainchain proto error")]
+    CusfMainchain(#[from] proto::Error),
+    #[error(transparent)]
+    Db(#[from] db::Error),
+    #[error("Database env error")]
+    DbEnv(#[from] env::Error),
+    #[error("Database write error")]
+    DbWrite(#[from] rwtxn::Error),
+    #[error("I/O error")]
+    Io(#[from] std::io::Error),
+    #[error("error requesting mainchain ancestors")]
+    MainchainAncestors(#[source] mainchain_task::ResponseError),
+    #[error("mempool error")]
+    MemPool(#[from] mempool::Error),
+    #[error("net error")]
+    Net(#[from] Box<net::Error>),
+    #[error("net task error")]
+    NetTask(#[source] Box<net_task::Error>),
+    #[error("No CUSF mainchain wallet client")]
+    NoCusfMainchainWalletClient,
+    #[error("peer info stream closed")]
+    PeerInfoRxClosed,
+    #[error("Receive mainchain task response cancelled")]
+    ReceiveMainchainTaskResponse,
+    #[error("Send mainchain task request failed")]
+    SendMainchainTaskRequest,
+    #[error("state error")]
+    State(#[source] Box<state::Error>),
+    #[error("Utreexo error: {0}")]
+    Utreexo(String),
+    #[error("Verify BMM error")]
+    VerifyBmm(anyhow::Error),
+}
+
+impl From<net::Error> for Error {
+    fn from(err: net::Error) -> Self {
+        Self::Net(Box::new(err))
+    }
+}
+
+impl From<net_task::Error> for Error {
+    fn from(err: net_task::Error) -> Self {
+        Self::NetTask(Box::new(err))
+    }
+}
+
+impl From<state::Error> for Error {
+    fn from(err: state::Error) -> Self {
+        Self::State(Box::new(err))
+    }
+}

--- a/lib/node/mod.rs
+++ b/lib/node/mod.rs
@@ -1,6 +1,6 @@
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
-    fmt::Debug,
     net::SocketAddr,
     path::Path,
     sync::Arc,
@@ -10,14 +10,14 @@ use bitcoin::amount::CheckedSum;
 use fallible_iterator::{FallibleIterator as _, IteratorExt as _};
 use futures::{Stream, future::BoxFuture};
 use heed::EnvFlags;
-use sneed::{DbError, Env, EnvError, RoTxn, RwTxnError, env};
+use sneed::{DbError, Env, EnvError, RoTxn, RwTxnError};
 use tokio::sync::Mutex;
 use tonic::transport::Channel;
 
 use crate::{
-    archive::{self, Archive},
+    archive::Archive,
     mempool::{self, MemPool},
-    net::{self, Net, Peer},
+    net::{Net, Peer},
     state::{self, State},
     types::{
         Accumulator, AmountOverflowError, AmountUnderflowError,
@@ -29,75 +29,12 @@ use crate::{
     util::Watchable,
 };
 
+pub mod error;
+pub use error::Error;
 mod mainchain_task;
-mod net_task;
-
 use mainchain_task::MainchainTaskHandle;
-
-use self::net_task::NetTaskHandle;
-
-#[derive(Debug, thiserror::Error, transitive::Transitive)]
-#[transitive(from(env::error::ReadTxn, EnvError))]
-pub enum Error {
-    #[error("address parse error")]
-    AddrParse(#[from] std::net::AddrParseError),
-    #[error(transparent)]
-    AmountOverflow(#[from] AmountOverflowError),
-    #[error(transparent)]
-    AmountUnderflow(#[from] AmountUnderflowError),
-    #[error("archive error")]
-    Archive(#[from] archive::Error),
-    #[error("CUSF mainchain proto error")]
-    CusfMainchain(#[from] proto::Error),
-    #[error(transparent)]
-    Db(#[from] DbError),
-    #[error("Database env error")]
-    DbEnv(#[from] EnvError),
-    #[error("Database write error")]
-    DbWrite(#[from] RwTxnError),
-    #[error("I/O error")]
-    Io(#[from] std::io::Error),
-    #[error("error requesting mainchain ancestors")]
-    MainchainAncestors(#[source] mainchain_task::ResponseError),
-    #[error("mempool error")]
-    MemPool(#[from] mempool::Error),
-    #[error("net error")]
-    Net(#[from] Box<net::Error>),
-    #[error("net task error")]
-    NetTask(#[source] Box<net_task::Error>),
-    #[error("No CUSF mainchain wallet client")]
-    NoCusfMainchainWalletClient,
-    #[error("peer info stream closed")]
-    PeerInfoRxClosed,
-    #[error("Receive mainchain task response cancelled")]
-    ReceiveMainchainTaskResponse,
-    #[error("Send mainchain task request failed")]
-    SendMainchainTaskRequest,
-    #[error("state error")]
-    State(#[source] Box<state::Error>),
-    #[error("Utreexo error: {0}")]
-    Utreexo(String),
-    #[error("Verify BMM error")]
-    VerifyBmm(anyhow::Error),
-}
-
-impl From<net::Error> for Error {
-    fn from(err: net::Error) -> Self {
-        Self::Net(Box::new(err))
-    }
-}
-
-impl From<net_task::Error> for Error {
-    fn from(err: net_task::Error) -> Self {
-        Self::NetTask(Box::new(err))
-    }
-}
-
-impl From<state::Error> for Error {
-    fn from(err: state::Error) -> Self {
-        Self::State(Box::new(err))
-    }
-}
+mod net_task;
+use net_task::NetTaskHandle;
 
 #[derive(Clone)]
 pub struct Node<MainchainTransport = Channel> {
@@ -253,12 +190,12 @@ where
     pub fn submit_transaction(
         &self,
         transaction: AuthorizedTransaction,
-    ) -> Result<(), Error> {
+    ) -> Result<(), error::SubmitTransaction> {
         {
-            let mut rotxn = self.env.write_txn().map_err(EnvError::from)?;
-            self.state.validate_transaction(&rotxn, &transaction)?;
-            self.mempool.put(&mut rotxn, &transaction)?;
-            rotxn.commit().map_err(RwTxnError::from)?;
+            let mut rwtxn = self.env.write_txn()?;
+            self.state.validate_transaction(&rwtxn, &transaction)?;
+            self.mempool.insert(&mut rwtxn, &transaction)?;
+            rwtxn.commit()?;
         }
         self.net.push_tx(Default::default(), transaction);
         Ok(())
@@ -268,7 +205,7 @@ where
         let rotxn = self.env.read_txn().map_err(EnvError::from)?;
         self.state
             .get_utxos(&rotxn)
-            .map_err(|err| DbError::from(err).into())
+            .map_err(|err| state::Error::from(err).into())
     }
 
     pub fn get_latest_failed_withdrawal_bundle_height(
@@ -449,28 +386,39 @@ where
         &self,
         number: usize,
     ) -> Result<(Vec<AuthorizedTransaction>, bitcoin::Amount), Error> {
-        let mut txn = self.env.write_txn().map_err(EnvError::from)?;
-        let transactions = self.mempool.take(&txn, number)?;
+        let mut rwtxn = self.env.write_txn()?;
+        let transactions = self.mempool.take(&rwtxn, number)?;
         let mut fee = bitcoin::Amount::ZERO;
         let mut returned_transactions = vec![];
         let mut spent_utxos = HashSet::new();
         for transaction in &transactions {
+            let txid =
+                std::cell::LazyCell::new(|| transaction.transaction.txid());
             let inputs: HashSet<_> =
                 transaction.transaction.inputs.iter().copied().collect();
             if !spent_utxos.is_disjoint(&inputs) {
                 // UTXO double spent
-                self.mempool
-                    .delete(&mut txn, transaction.transaction.txid())?;
+                self.mempool.delete(&mut rwtxn, *txid)?;
                 continue;
             }
-            if self.state.validate_transaction(&txn, transaction).is_err() {
-                self.mempool
-                    .delete(&mut txn, transaction.transaction.txid())?;
+            if self
+                .state
+                .validate_transaction(&rwtxn, transaction)
+                .is_err()
+            {
+                self.mempool.delete(&mut rwtxn, *txid)?;
                 continue;
             }
             let filled_transaction = self
                 .state
-                .fill_transaction(&txn, &transaction.transaction)?;
+                .fill_transaction(
+                    &rwtxn,
+                    Cow::Borrowed(&transaction.transaction),
+                )
+                .map_err(|err| state::Error::FillTransaction {
+                    source: err,
+                    txid: *txid,
+                })?;
             let mut value_in: bitcoin::Amount = filled_transaction
                 .spent_utxos
                 .iter()
@@ -508,7 +456,7 @@ where
             returned_transactions.push(transaction.clone());
             spent_utxos.extend(transaction.transaction.inputs.clone());
         }
-        txn.commit().map_err(RwTxnError::from)?;
+        rwtxn.commit()?;
         Ok((returned_transactions, fee))
     }
 

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -252,7 +252,10 @@ fn disconnect_tip_(
         prev_frontier.as_ref(),
     )?;
     for transaction in tip_body.authorized_transactions().iter().rev() {
-        mempool.put(rwtxn, transaction)?;
+        let _: Result<(), mempool::error::TxRejected> = mempool
+            .insert(rwtxn, transaction)
+            .into_nested()
+            .map_err(mempool::Error::from)?;
     }
     mempool.regenerate_proofs(rwtxn, &prev_accumulator)?;
     Ok(())
@@ -1160,30 +1163,34 @@ impl NetTask {
                             // nullifier already held). Such conflicts are not
                             // fatal to this node: drop the transaction without
                             // relaying instead of terminating the net task.
-                            match self.ctxt.mempool.put(&mut rwtxn, &new_tx) {
-                                Ok(()) => {}
-                                Err(
-                                    err @ (mempool::Error::UtxoDoubleSpent {
-                                        ..
-                                    }
-                                    | mempool::Error::NullifierDoubleSpent {
-                                        ..
-                                    }),
-                                ) => {
+                            match self
+                                .ctxt
+                                .mempool
+                                .insert(&mut rwtxn, &new_tx)
+                                .into_nested()
+                                .map_err(mempool::Error::from)?
+                            {
+                                Ok(()) => {
+                                    rwtxn.commit()?;
+                                    // broadcast
+                                    let () = self.ctxt.net.push_tx(
+                                        HashSet::from_iter([addr]),
+                                        *new_tx,
+                                    );
+                                }
+                                Err(jfyi) => {
+                                    drop(rwtxn);
+                                    let reason: mempool::error::TxRejected =
+                                        jfyi;
+                                    let txid = new_tx.transaction.txid();
                                     tracing::warn!(
                                         %addr,
-                                        "Dropping conflicting transaction from peer: {err}"
+                                        %txid,
+                                        "Dropping conflicting transaction from peer: {:#}",
+                                        ErrorChain::new(&reason),
                                     );
-                                    continue;
                                 }
-                                Err(err) => return Err(err.into()),
                             }
-                            rwtxn.commit().map_err(RwTxnError::from)?;
-                            // broadcast
-                            let () = self
-                                .ctxt
-                                .net
-                                .push_tx(HashSet::from_iter([addr]), *new_tx);
                         }
                         PeerConnectionInfo::Response(boxed) => {
                             let (resp, req) = *boxed;
@@ -1329,7 +1336,7 @@ mod test {
     // a peer's invalid block (value out > value in) must not be fatal
     #[test]
     fn invalid_peer_block_is_not_fatal() {
-        let err = Error::State(Box::new(state::Error::NotEnoughValueIn));
+        let err = Error::State(Box::new(state::Error::NotEnoughFees));
         assert!(!is_fatal_reorg_error(&err));
     }
 

--- a/lib/node/net_task.rs
+++ b/lib/node/net_task.rs
@@ -1155,7 +1155,29 @@ impl NetTask {
                                 &rwtxn,
                                 &mut new_tx.transaction,
                             )?;
-                            self.ctxt.mempool.put(&mut rwtxn, &new_tx)?;
+                            // A peer-relayed transaction may conflict with the
+                            // local mempool (double-spending an outpoint or
+                            // nullifier already held). Such conflicts are not
+                            // fatal to this node: drop the transaction without
+                            // relaying instead of terminating the net task.
+                            match self.ctxt.mempool.put(&mut rwtxn, &new_tx) {
+                                Ok(()) => {}
+                                Err(
+                                    err @ (mempool::Error::UtxoDoubleSpent {
+                                        ..
+                                    }
+                                    | mempool::Error::NullifierDoubleSpent {
+                                        ..
+                                    }),
+                                ) => {
+                                    tracing::warn!(
+                                        %addr,
+                                        "Dropping conflicting transaction from peer: {err}"
+                                    );
+                                    continue;
+                                }
+                                Err(err) => return Err(err.into()),
+                            }
                             rwtxn.commit().map_err(RwTxnError::from)?;
                             // broadcast
                             let () = self

--- a/lib/state/block.rs
+++ b/lib/state/block.rs
@@ -1,5 +1,7 @@
 //! Connect and disconnect blocks
 
+use std::borrow::Cow;
+
 use rayon::prelude::*;
 use rustreexo::accumulator::node_hash::BitcoinNodeHash;
 use sneed::{RoTxn, RwTxn};
@@ -71,7 +73,14 @@ pub fn validate(
     let filled_transactions: Vec<_> = body
         .transactions
         .iter()
-        .map(|t| state.fill_transaction(rotxn, t))
+        .map(|t| {
+            state
+                .fill_transaction(rotxn, Cow::Borrowed(t))
+                .map_err(|err| Error::FillTransaction {
+                    source: err,
+                    txid: t.txid(),
+                })
+        })
         .collect::<Result<_, _>>()?;
     let total_inputs = calculate_total_inputs(body);
 
@@ -96,7 +105,12 @@ pub fn validate(
         if let Some(orchard_bundle) =
             filled_transaction.transaction.orchard_bundle.as_ref()
         {
-            let () = state.validate_orchard_anchor(rotxn, orchard_bundle)?;
+            let () = state
+                .validate_orchard_anchor(rotxn, orchard_bundle)
+                .map_err(|err| Error::ValidateOrchardAnchor {
+                    source: err,
+                    txid,
+                })?;
         }
         // hashes of spent utxos, used to verify the utreexo proof
         let mut spent_utxo_hashes = Vec::<BitcoinNodeHash>::with_capacity(
@@ -120,7 +134,14 @@ pub fn validate(
             accumulator_diff.insert((&pointed_output).into());
         }
         total_fees = total_fees
-            .checked_add(state.validate_filled_transaction(filled_transaction)?)
+            .checked_add(
+                state
+                    .validate_filled_transaction(filled_transaction)
+                    .map_err(|err| Error::ValidateFilledTransaction {
+                        source: err,
+                        txid,
+                    })?,
+            )
             .ok_or(AmountOverflowError)?;
         // verify utreexo proof
         if !accumulator
@@ -205,7 +226,14 @@ pub fn prevalidate(
     let filled_transactions: Vec<_> = body
         .transactions
         .iter()
-        .map(|t| state.fill_transaction(rotxn, t))
+        .map(|t| {
+            state
+                .fill_transaction(rotxn, Cow::Borrowed(t))
+                .map_err(|err| Error::FillTransaction {
+                    source: err,
+                    txid: t.txid(),
+                })
+        })
         .collect::<Result<_, _>>()?;
     let total_inputs = calculate_total_inputs(body);
 
@@ -230,7 +258,12 @@ pub fn prevalidate(
         if let Some(orchard_bundle) =
             filled_transaction.transaction.orchard_bundle.as_ref()
         {
-            let () = state.validate_orchard_anchor(rotxn, orchard_bundle)?;
+            let () = state
+                .validate_orchard_anchor(rotxn, orchard_bundle)
+                .map_err(|err| Error::ValidateOrchardAnchor {
+                    source: err,
+                    txid,
+                })?;
         }
         // hashes of spent utxos, used to verify the utreexo proof
         let mut spent_utxo_hashes = Vec::<BitcoinNodeHash>::with_capacity(
@@ -254,7 +287,14 @@ pub fn prevalidate(
             accumulator_diff.insert((&pointed_output).into());
         }
         total_fees = total_fees
-            .checked_add(state.validate_filled_transaction(filled_transaction)?)
+            .checked_add(
+                state
+                    .validate_filled_transaction(filled_transaction)
+                    .map_err(|err| Error::ValidateFilledTransaction {
+                        source: err,
+                        txid,
+                    })?,
+            )
             .ok_or(AmountOverflowError)?;
         // verify utreexo proof
         if !accumulator
@@ -709,6 +749,8 @@ pub fn disconnect_tip(
 
 #[cfg(test)]
 mod test {
+    use std::borrow::Cow;
+
     use crate::state::test::{fresh_state, value_output};
 
     #[test]
@@ -812,7 +854,10 @@ mod test {
         //   builds from the SUPPLIED utxo_hash.
         let filled = {
             let rotxn = env.read_txn()?;
-            state.fill_transaction(&rotxn, &body.transactions[0])?
+            state.fill_transaction(
+                &rotxn,
+                Cow::Borrowed(&body.transactions[0]),
+            )?
         };
 
         // tx validation REJECTS the outpoint/utxo_hash mismatch.

--- a/lib/state/error.rs
+++ b/lib/state/error.rs
@@ -1,11 +1,130 @@
+use error_fatality::{Fatality, Split};
 use sneed::{db::error as db, env::error as env, rwtxn::error as rwtxn};
 use thiserror::Error;
 use transitive::Transitive;
 
 use crate::types::{
-    AmountOverflowError, AmountUnderflowError, BlockHash, M6id, MerkleRoot,
-    OutPoint, Txid, UtreexoError, WithdrawalBundleError, orchard,
+    AmountOverflowError, AmountUnderflowError, BlockHash, Hash, M6id,
+    MerkleRoot, OutPoint, TransparentAddress, Txid, UtreexoError,
+    WithdrawalBundleError, orchard,
 };
+
+#[derive(Debug, Error)]
+#[error(
+    "Computed Utxo hash ({}) for input ({}) does not match input hash ({})",
+    hex::encode(.computed),
+    .outpoint,
+    hex::encode(.input_hash),
+)]
+pub struct UtxoHashMismatch {
+    pub(in crate::state) computed: Hash,
+    pub(in crate::state) outpoint: OutPoint,
+    pub(in crate::state) input_hash: Hash,
+}
+
+#[derive(Debug, Error, Fatality, Split)]
+pub enum ValidateFilledTransaction {
+    #[error(transparent)]
+    #[fatal(false)]
+    AmountOverflow(#[from] AmountOverflowError),
+    #[error(transparent)]
+    #[fatal(false)]
+    AmountUnderflow(#[from] AmountUnderflowError),
+    #[error("value in is less than value out")]
+    #[fatal(false)]
+    NotEnoughValueIn,
+    #[error("withdrawal output {outpoint} cannot be spent by a transaction")]
+    #[fatal(false)]
+    SpendWithdrawalOutput { outpoint: OutPoint },
+    #[error(transparent)]
+    #[fatal(false)]
+    UtxoHashMismatch(#[from] Box<UtxoHashMismatch>),
+}
+
+impl From<UtxoHashMismatch> for ValidateFilledTransaction {
+    fn from(err: UtxoHashMismatch) -> Self {
+        Self::UtxoHashMismatch(Box::new(err))
+    }
+}
+
+#[derive(Debug, Error)]
+#[error("utxo {outpoint} doesn't exist")]
+#[repr(transparent)]
+pub struct NoUtxo {
+    pub outpoint: OutPoint,
+}
+
+/// Non-fatal variants indicate tx rejection reason
+#[derive(Debug, Error, Fatality)]
+pub enum FillTransaction {
+    #[error(transparent)]
+    #[fatal(true)]
+    DbTryGet(#[from] Box<db::TryGet>),
+    #[error(transparent)]
+    #[fatal(false)]
+    NoUtxo(#[from] NoUtxo),
+}
+
+impl From<db::TryGet> for FillTransaction {
+    fn from(err: db::TryGet) -> Self {
+        Self::DbTryGet(Box::new(err))
+    }
+}
+
+impl Split for FillTransaction {
+    type Fatal = db::TryGet;
+    type Jfyi = NoUtxo;
+
+    fn split(self) -> std::result::Result<Self::Jfyi, Self::Fatal> {
+        match self {
+            Self::DbTryGet(err) => Err(*err),
+            Self::NoUtxo(jfyi) => Ok(jfyi),
+        }
+    }
+}
+
+/// Non-fatal variants indicate tx rejection reason
+#[derive(Debug, Error, Fatality, Split)]
+pub enum ValidateOrchardAnchor {
+    #[error(transparent)]
+    #[fatal(true)]
+    DbTryGet(#[from] Box<db::TryGet>),
+    #[error("The empty anchor is only allowed if spends are disabled")]
+    #[fatal(false)]
+    EmptyAnchor,
+    #[error("Invalid anchor (`{anchor}`)")]
+    #[fatal(false)]
+    InvalidAnchor { anchor: orchard::Anchor },
+}
+
+impl From<db::TryGet> for ValidateOrchardAnchor {
+    fn from(err: db::TryGet) -> Self {
+        Self::DbTryGet(Box::new(err))
+    }
+}
+
+/// Non-fatal variants indicate tx rejection reason
+#[derive(Debug, Error, Fatality, Split)]
+pub enum ValidateTransaction {
+    #[error("failed to verify authorizations")]
+    #[fatal(forward)]
+    Authorization(#[from] crate::authorization::Error),
+    #[error(transparent)]
+    #[fatal(forward)]
+    Filled(#[from] ValidateFilledTransaction),
+    #[error(transparent)]
+    #[fatal(forward)]
+    FillTransaction(#[from] FillTransaction),
+    #[error("failed to validate orchard anchor")]
+    #[fatal(forward)]
+    OrchardAnchor(#[from] ValidateOrchardAnchor),
+    #[error("wrong verifying key hash ({vk_hash}) for address ({address})")]
+    #[fatal(false)]
+    WrongVerifyingKeyForAddress {
+        address: TransparentAddress,
+        vk_hash: TransparentAddress,
+    },
+}
 
 #[derive(Debug, Error)]
 #[error(
@@ -44,10 +163,6 @@ pub enum Orchard {
     AppendCommitment,
     #[error(transparent)]
     Db(#[from] Box<db::Error>),
-    #[error("The empty anchor is only allowed if spends are disabled")]
-    EmptyAnchor,
-    #[error("Invalid anchor (`{anchor}`)")]
-    InvalidAnchor { anchor: orchard::Anchor },
     #[error("Nullifier missing (`{nullifier}`)")]
     MissingNullifier { nullifier: orchard::Nullifier },
     #[error("Nullifier double spent (`{nullifier}`)")]
@@ -58,12 +173,6 @@ impl From<db::Error> for Orchard {
     fn from(err: db::Error) -> Self {
         Self::Db(Box::new(err))
     }
-}
-
-#[derive(Debug, Error)]
-#[error("utxo {outpoint} doesn't exist")]
-pub struct NoUtxo {
-    pub outpoint: OutPoint,
 }
 
 #[allow(clippy::duplicated_attributes)]
@@ -237,8 +346,6 @@ pub enum Error {
     AuthorizationError,
     #[error(transparent)]
     AmountOverflow(#[from] AmountOverflowError),
-    #[error(transparent)]
-    AmountUnderflow(#[from] AmountUnderflowError),
     #[error("body too large")]
     BodyTooLarge,
     #[error(transparent)]
@@ -249,6 +356,8 @@ pub enum Error {
     ConnectWithdrawalBundleSubmitted(#[from] ConnectWithdrawalBundleSubmitted),
     #[error(transparent)]
     Db(Box<sneed::Error>),
+    #[error("failed to fill inputs for tx ({txid})")]
+    FillTransaction { source: FillTransaction, txid: Txid },
     #[error(transparent)]
     InvalidBody(InvalidBody),
     #[error("invalid header: {0}")]
@@ -261,12 +370,8 @@ pub enum Error {
     NoTip,
     #[error("stxo {outpoint} doesn't exist")]
     NoStxo { outpoint: OutPoint },
-    #[error("value in is less than value out")]
-    NotEnoughValueIn,
     #[error(transparent)]
     NoUtxo(#[from] NoUtxo),
-    #[error("withdrawal output {outpoint} cannot be spent by a transaction")]
-    SpendWithdrawalOutput { outpoint: OutPoint },
     #[error("Withdrawal bundle event block doesn't exist")]
     NoWithdrawalBundleEventBlock,
     #[error("Orchard error")]
@@ -281,17 +386,6 @@ pub enum Error {
     UtreexoRootsMismatch,
     #[error("utxo double spent")]
     UtxoDoubleSpent,
-    #[error(
-        "Computed Utxo hash ({}) for input ({}) does not match input hash ({})",
-        hex::encode(.computed),
-        .outpoint,
-        hex::encode(.input_hash),
-    )]
-    UtxoHashMismatch {
-        computed: crate::types::Hash,
-        outpoint: OutPoint,
-        input_hash: crate::types::Hash,
-    },
     #[error("too many sigops")]
     TooManySigops,
     #[error(
@@ -320,6 +414,16 @@ pub enum Error {
     UnknownWithdrawalBundleReconfirmed {
         event_block_hash: bitcoin::BlockHash,
         m6id: M6id,
+    },
+    #[error("failed to validate tx ({txid})")]
+    ValidateFilledTransaction {
+        source: ValidateFilledTransaction,
+        txid: Txid,
+    },
+    #[error("failed to validate orchard anchor for tx ({txid})")]
+    ValidateOrchardAnchor {
+        source: ValidateOrchardAnchor,
+        txid: Txid,
     },
     #[error("wrong public key for address")]
     WrongPubKeyForAddress,

--- a/lib/state/mod.rs
+++ b/lib/state/mod.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::{
+    borrow::Cow,
+    collections::{BTreeMap, HashMap, HashSet},
+};
 
 use fallible_iterator::FallibleIterator as _;
 use futures::Stream;
@@ -25,16 +28,15 @@ use crate::{
 };
 
 mod block;
-mod error;
+pub mod error;
+pub use error::Error;
 mod orchard;
+pub use orchard::Orchard;
 #[cfg(test)]
 mod orchard_anchor_tests;
 mod rollback;
-mod two_way_peg_data;
-
-pub use error::Error;
-pub use orchard::Orchard;
 use rollback::RollBack;
+mod two_way_peg_data;
 
 pub const WITHDRAWAL_BUNDLE_FAILURE_GAP: u32 = 4;
 
@@ -280,8 +282,8 @@ impl State {
     pub fn fill_transaction(
         &self,
         rotxn: &RoTxn,
-        transaction: &Transaction,
-    ) -> Result<FilledTransaction, Error> {
+        transaction: Cow<'_, Transaction>,
+    ) -> Result<FilledTransaction, error::FillTransaction> {
         let mut spent_utxos = vec![];
         for (outpoint, _) in &transaction.inputs {
             let key = OutPointKey::from(outpoint);
@@ -293,7 +295,7 @@ impl State {
         }
         Ok(FilledTransaction {
             spent_utxos,
-            transaction: transaction.clone(),
+            transaction: transaction.into_owned(),
         })
     }
 
@@ -321,14 +323,14 @@ impl State {
 
     fn validate_utxo_hashes(
         transaction: &FilledTransaction,
-    ) -> Result<(), Error> {
+    ) -> Result<(), error::UtxoHashMismatch> {
         for (outpoint, utxo_hash, output) in transaction.inputs() {
             let outpoint = *outpoint;
             let utxo_hash = *utxo_hash;
             let computed_utxo_hash =
                 crate::types::hash(&PointedOutputRef { outpoint, output });
             if utxo_hash != computed_utxo_hash {
-                return Err(Error::UtxoHashMismatch {
+                return Err(error::UtxoHashMismatch {
                     computed: computed_utxo_hash,
                     outpoint,
                     input_hash: utxo_hash,
@@ -341,7 +343,7 @@ impl State {
     pub fn validate_filled_transaction(
         &self,
         transaction: &FilledTransaction,
-    ) -> Result<bitcoin::Amount, Error> {
+    ) -> Result<bitcoin::Amount, error::ValidateFilledTransaction> {
         let () = Self::validate_utxo_hashes(transaction)?;
         let mut value_in = bitcoin::Amount::ZERO;
         let mut value_out = bitcoin::Amount::ZERO;
@@ -349,9 +351,11 @@ impl State {
             // a withdrawal output is committed to a bundle and can only be
             // spent by the bundle, never by a transaction
             if utxo.content.is_withdrawal() {
-                return Err(Error::SpendWithdrawalOutput {
-                    outpoint: *outpoint,
-                });
+                let err =
+                    error::ValidateFilledTransaction::SpendWithdrawalOutput {
+                        outpoint: *outpoint,
+                    };
+                return Err(err);
             }
             value_in = value_in
                 .checked_add(utxo.get_value())
@@ -377,7 +381,7 @@ impl State {
             }
         }
         if value_out > value_in {
-            return Err(Error::NotEnoughValueIn);
+            return Err(error::ValidateFilledTransaction::NotEnoughValueIn);
         }
         value_in
             .checked_sub(value_out)
@@ -390,19 +394,19 @@ impl State {
         &self,
         rotxn: &RoTxn,
         orchard_bundle: &types::orchard::Bundle<types::orchard::Authorized>,
-    ) -> Result<(), Error> {
+    ) -> Result<(), error::ValidateOrchardAnchor> {
         let anchor = *orchard_bundle.anchor();
         if anchor == types::orchard::Anchor::empty_tree()
             && orchard_bundle.flags().spends_enabled()
         {
-            return Err(error::Orchard::EmptyAnchor.into());
+            return Err(error::ValidateOrchardAnchor::EmptyAnchor);
         }
         if !self
             .orchard
             .historical_roots()
             .contains_key(rotxn, &anchor)?
         {
-            return Err(error::Orchard::InvalidAnchor { anchor }.into());
+            return Err(error::ValidateOrchardAnchor::InvalidAnchor { anchor });
         }
         Ok(())
     }
@@ -411,16 +415,22 @@ impl State {
         &self,
         rotxn: &RoTxn,
         transaction: &AuthorizedTransaction,
-    ) -> Result<bitcoin::Amount, Error> {
-        let filled_transaction =
-            self.fill_transaction(rotxn, &transaction.transaction)?;
+    ) -> Result<bitcoin::Amount, error::ValidateTransaction> {
+        let filled_transaction = self
+            .fill_transaction(rotxn, Cow::Borrowed(&transaction.transaction))?;
         for (authorization, spent_utxo) in transaction
             .authorizations
             .iter()
             .zip(filled_transaction.spent_utxos.iter())
         {
-            if authorization.get_address() != spent_utxo.address {
-                return Err(Error::WrongPubKeyForAddress);
+            let auth_address = authorization.get_address();
+            if auth_address != spent_utxo.address {
+                let err =
+                    error::ValidateTransaction::WrongVerifyingKeyForAddress {
+                        address: spent_utxo.address,
+                        vk_hash: auth_address,
+                    };
+                return Err(err);
             }
         }
         // Check anchor
@@ -429,9 +439,7 @@ impl State {
         {
             let () = self.validate_orchard_anchor(rotxn, orchard_bundle)?;
         }
-        if Authorization::verify_transaction(transaction).is_err() {
-            return Err(Error::AuthorizationError);
-        }
+        let () = Authorization::verify_transaction(transaction)?;
         let fee = self.validate_filled_transaction(&filled_transaction)?;
         Ok(fee)
     }
@@ -665,7 +673,7 @@ mod test {
     use bitcoin::hashes::Hash as _;
 
     use crate::{
-        state::State,
+        state::{State, error},
         types::{
             FilledTransaction, InPoint, OutPoint, OutPointKey, Output,
             OutputContent, PointedOutputRef, SpentOutput, Transaction,
@@ -749,7 +757,7 @@ mod test {
         };
         assert!(matches!(
             state.validate_filled_transaction(&tx),
-            Err(crate::state::Error::SpendWithdrawalOutput { .. })
+            Err(error::ValidateFilledTransaction::SpendWithdrawalOutput { .. })
         ));
         Ok(())
     }

--- a/lib/state/orchard_anchor_tests.rs
+++ b/lib/state/orchard_anchor_tests.rs
@@ -21,6 +21,7 @@ use crate::{
     state::{
         State,
         error::{self, Error},
+        test::fresh_state,
     },
     types::{
         AccumulatorDiff, AuthorizedTransaction, Body, Header, OutPoint, Output,
@@ -31,31 +32,6 @@ use crate::{
 
 // The forged note's value: 1,000,000 BTC in sats. Fits in i64 value_balance.
 const FORGED_SATS: u64 = 1_000_000 * 100_000_000;
-
-/// Temp directory for an LMDB env, removed on drop.
-struct TempDir(std::path::PathBuf);
-
-impl TempDir {
-    fn new() -> Self {
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let mut path = std::env::temp_dir();
-        path.push(format!(
-            "thunder_orchard_anchor_test_{}_{nanos}",
-            std::process::id()
-        ));
-        std::fs::create_dir_all(&path).unwrap();
-        Self(path)
-    }
-}
-
-impl Drop for TempDir {
-    fn drop(&mut self) {
-        let _unused = std::fs::remove_dir_all(&self.0);
-    }
-}
 
 /// Build a position-0 merkle path and the resulting anchor for a single leaf,
 /// without ever inserting the leaf into the chain's note-commitment tree.
@@ -228,35 +204,30 @@ fn expected_roots(
 }
 
 #[test]
-fn forged_anchor_rejected_in_block() {
-    let tmp = TempDir::new();
-    let env = {
-        let mut opts = heed::EnvOpenOptions::new();
-        opts.map_size(1024 * 1024 * 1024).max_dbs(State::NUM_DBS);
-        unsafe { sneed::Env::open(&opts, &tmp.0) }.unwrap()
-    };
-    let state = State::new(&env).unwrap();
+fn forged_anchor_rejected_in_block() -> anyhow::Result<()> {
+    let (_temp_dir, env, state) =
+        fresh_state("forged_anchor_rejected_in_block")?;
 
     let attacker_addr = TransparentAddress([0x11; 20]);
     let empty_proof = {
-        let rotxn = env.read_txn().unwrap();
-        state
-            .get_utreexo_proof(&rotxn, std::iter::empty::<&PointedOutput>())
-            .unwrap()
+        let rotxn = env.read_txn()?;
+        state.get_utreexo_proof(&rotxn, std::iter::empty::<&PointedOutput>())?
     };
 
     let auth_tx = build_attack_tx(attacker_addr, empty_proof);
 
     // Mempool path must reject the forged anchor.
     {
-        let rotxn = env.read_txn().unwrap();
+        let rotxn = env.read_txn()?;
         let err = state
             .validate_transaction(&rotxn, &auth_tx)
             .expect_err("mempool must reject forged anchor");
-        assert!(
-            matches!(err, Error::Orchard(error::Orchard::InvalidAnchor { .. })),
-            "expected InvalidAnchor, got: {err:?}"
-        );
+        anyhow::ensure!(matches!(
+            err,
+            error::ValidateTransaction::OrchardAnchor(
+                error::ValidateOrchardAnchor::InvalidAnchor { .. }
+            )
+        ),);
     }
 
     // Block-validation path must reject the same transaction. Before the fix,
@@ -272,13 +243,17 @@ fn forged_anchor_rejected_in_block() {
         }
     };
     {
-        let rotxn = env.read_txn().unwrap();
+        let rotxn = env.read_txn()?;
         let err = state
             .validate_block(&rotxn, &header, &body)
             .expect_err("block path must reject forged anchor");
-        assert!(
-            matches!(err, Error::Orchard(error::Orchard::InvalidAnchor { .. })),
-            "expected InvalidAnchor, got: {err:?}"
-        );
+        anyhow::ensure!(matches!(
+            err,
+            Error::ValidateOrchardAnchor {
+                source: error::ValidateOrchardAnchor::InvalidAnchor { .. },
+                txid: _,
+            }
+        ));
     }
+    Ok(())
 }


### PR DESCRIPTION
## Summary

net_task NewTransaction arm now catches mempool UtxoDoubleSpent/NullifierDoubleSpent conflicts (logs + continues) instead of propagating them and halting the net task, while still treating other mempool errors as fatal.

## The bug

Mempool: a peer transaction conflict halts the net task

Severity: Medium. Finding (access-controlled): https://giaki3003.tech/#/findings/20260618-1646-kimiclaw-confirm-openclaw-thunder-orchard-peer-tx-conflict-nettask-halt

## Stack

Part of a stacked series for `thunder-orchard` (fix 1 of 2). First in the stack (based on `master`).