### PR TITLE
fix: Orchard: block disconnect restores an outgoing note as a spent note

### DIFF
--- a/lib/wallet/mod.rs
+++ b/lib/wallet/mod.rs
@@ -1409,7 +1409,7 @@ impl Wallet {
             {
                 decrypted_outgoing_note_idxs.insert(idx);
                 let nf = *orchard_bundle.actions()[idx].nullifier();
-                let Some((_, position)) = self
+                let Some((spent_note, position)) = self
                     .orchard_spent_notes
                     .try_get(&rwtxn, &(txid, idx as u32))?
                 else {
@@ -1424,7 +1424,11 @@ impl Wallet {
                 let _: bool = self
                     .orchard_spent_notes
                     .delete(&mut rwtxn, &(txid, idx as u32))?;
-                self.orchard_notes.put(&mut rwtxn, &nf, &(note, position))?;
+                self.orchard_notes.put(
+                    &mut rwtxn,
+                    &nf,
+                    &(spent_note, position),
+                )?;
             }
             for (idx, action) in
                 orchard_bundle.actions().iter().enumerate().rev()


### PR DESCRIPTION
## Summary

In `disconnect_orchard_block` (lib/wallet/mod.rs), the decrypted-outgoing path now binds and restores the saved `(spent_note, position)` from `orchard_spent_notes` instead of writing back the recovered outgoing `note`.

## The bug

Orchard: block disconnect restores an outgoing note as a spent note

Severity: Low. Finding (access-controlled): https://giaki3003.tech/#/findings/20260618-0647-kimiclaw-confirm-openclaw-thunder-orchard-wallet-disconnect-restores-output-note

## Stack

Part of a stacked series for `thunder-orchard` (fix 2 of 2). Builds on https://github.com/iwakura-rein/thunder-orchard/pull/26 — best merged bottom-up; I'll rebase to keep each diff minimal as earlier ones land.